### PR TITLE
Docs: fix broken Quantx banner image in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,11 +205,10 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 
 <div align="center">
 
-A **[QNTX](https://qntx.fun)** open-source project.
+A **[QuantX](https://qntx.fun)** open-source project.
 
-<a href="https://qntx.fun"><img alt="QNTX" width="369" src="https://raw.githubusercontent.com/qntx/.github/main/profile/qntx-banner.svg" /></a>
+<a href="https://qntx.fun"><img alt="QuantX" width="369" src="https://raw.githubusercontent.com/qntx/.github/main/profile/qntx.svg" /></a>
 
-<!--prettier-ignore-->
 Code is law. We write both.
 
 </div>


### PR DESCRIPTION
# Description

The previous raw GitHub asset URL returns **404**, so the README footer image does not render. The file now lives at `profile/qntx.svg` under `qntx/.github`.

## Changes

- Fix broken QuantX footer banner in `README.md` (`qntx-banner.svg` → `qntx.svg`)
- Update branding label from **QNTX** to **QuantX** to match current naming
- Link target remains `https://qntx.fun`

closes #31 