### PR TITLE
Feat/issue 35 remove bitcoin dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,25 +89,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
-name = "base58ck"
-version = "0.1.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365c0acd5b2e8dd0111a46c4faea83fb3cfb6e39a49a7c73a06e090db7b2eff0"
-dependencies = [
- "bitcoin_hashes",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bech32"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "bech32"
@@ -126,7 +111,7 @@ dependencies = [
  "k256",
  "rand_core 0.6.4",
  "ripemd 0.1.3",
- "secp256k1 0.27.0",
+ "secp256k1",
  "sha2 0.10.9",
  "subtle",
  "zeroize",
@@ -146,65 +131,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin"
-version = "0.32.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed8ccb78a9ff7a6fbb90e2fb9b8588b4a9928d49d8af3cb789108a84ea6b0ce"
-dependencies = [
- "base58ck",
- "bech32 0.11.1",
- "bitcoin-io",
- "bitcoin-units",
- "bitcoin_hashes",
- "hex-conservative 0.2.2",
- "hex_lit",
- "secp256k1 0.29.1",
-]
-
-[[package]]
-name = "bitcoin-consensus-encoding"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
-dependencies = [
- "bitcoin-internals",
-]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
-dependencies = [
- "hex-conservative 0.3.2",
-]
-
-[[package]]
-name = "bitcoin-io"
-version = "0.1.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
-dependencies = [
- "bitcoin-consensus-encoding",
-]
-
-[[package]]
-name = "bitcoin-units"
-version = "0.1.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb95693f371d089a4b5b6fc41c6f3ea6e01ee8c15388335dfac8ea685173b51"
-dependencies = [
- "bitcoin-consensus-encoding",
-]
-
-[[package]]
 name = "bitcoin_hashes"
 version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
- "bitcoin-io",
- "hex-conservative 0.2.2",
+ "hex-conservative",
 ]
 
 [[package]]
@@ -641,21 +573,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex-conservative"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
-name = "hex_lit"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
-
-[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,9 +678,14 @@ dependencies = [
 name = "kobe-btc"
 version = "2.0.1"
 dependencies = [
- "bitcoin",
+ "bech32",
+ "bip32",
+ "bs58",
  "hex",
+ "k256",
  "kobe-primitives",
+ "ripemd 0.2.0",
+ "sha2 0.11.0",
  "zeroize",
 ]
 
@@ -783,7 +705,7 @@ dependencies = [
 name = "kobe-cosmos"
 version = "2.0.1"
 dependencies = [
- "bech32 0.12.0",
+ "bech32",
  "kobe-primitives",
  "ripemd 0.2.0",
  "sha2 0.11.0",
@@ -809,7 +731,7 @@ dependencies = [
 name = "kobe-nostr"
 version = "2.0.1"
 dependencies = [
- "bech32 0.12.0",
+ "bech32",
  "kobe-primitives",
  "zeroize",
 ]
@@ -833,7 +755,7 @@ dependencies = [
 name = "kobe-spark"
 version = "2.0.1"
 dependencies = [
- "bech32 0.12.0",
+ "bech32",
  "hex",
  "kobe-primitives",
 ]
@@ -1139,17 +1061,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
- "secp256k1-sys 0.8.2",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
-dependencies = [
- "bitcoin_hashes",
- "secp256k1-sys 0.10.1",
+ "secp256k1-sys",
 ]
 
 [[package]]
@@ -1157,15 +1069,6 @@ name = "secp256k1-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4473013577ec77b4ee3668179ef1186df3146e2cf2d927bd200974c6fe60fd99"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
 bech32 = { version = "0.12.0", default-features = false, features = ["alloc"] }
 bip32 = { version = "0.5.3", default-features = false, features = ["secp256k1", "alloc"] }
 bip39 = { version = "2.2.2", default-features = false }
-bitcoin = { version = "0.32.100", default-features = false }
 blake2 = { version = "0.10.6", default-features = false }
 bs58 = { version = "0.5.1", default-features = false, features = ["alloc"] }
 ed25519-dalek = { version = "3.0.0", default-features = false }

--- a/crates/kobe-btc/Cargo.toml
+++ b/crates/kobe-btc/Cargo.toml
@@ -12,12 +12,17 @@ categories = ["cryptography", "no-std"]
 
 [features]
 default = ["std"]
-std = ["alloc", "kobe-primitives/std", "bitcoin/std", "zeroize/std"]
+std = ["alloc", "kobe-primitives/std", "zeroize/std"]
 alloc = ["kobe-primitives/alloc", "zeroize/alloc"]
 
 [dependencies]
-kobe-primitives.workspace = true
-bitcoin.workspace = true
+bech32.workspace = true
+bip32.workspace = true
+bs58.workspace = true
+kobe-primitives = { workspace = true, features = ["bip32"] }
+k256.workspace = true
+ripemd.workspace = true
+sha2.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]

--- a/crates/kobe-btc/src/address.rs
+++ b/crates/kobe-btc/src/address.rs
@@ -1,92 +1,206 @@
-//! Bitcoin address creation utilities.
-//!
-//! This module provides shared address creation functionality used by both
-//! HD derivation and standard wallet implementations.
+//! Bitcoin address encoding (public data only — no private keys).
 
-use bitcoin::key::CompressedPublicKey;
-use bitcoin::secp256k1::Secp256k1;
-use bitcoin::{Address, PublicKey};
+use alloc::format;
+use alloc::string::String;
+
+use k256::elliptic_curve::PrimeField;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::{ProjectivePoint, PublicKey, Scalar};
+use kobe_primitives::DeriveError;
+use ripemd::Ripemd160;
+use sha2::{Digest, Sha256};
 
 use crate::{AddressType, Network};
 
-/// Create a Bitcoin address from a compressed public key.
-///
-/// This function handles all supported address types (P2PKH, P2SH-P2WPKH,
-/// P2WPKH, and P2TR) and is used by both the HD deriver and standard wallet.
-///
-/// # Arguments
-///
-/// * `public_key` - The compressed public key to create an address from
-/// * `network` - The Bitcoin network (mainnet or testnet)
-/// * `address_type` - The type of address to create
-///
-/// # Returns
-///
-/// A Bitcoin address of the specified type.
-#[must_use]
+/// Build an address string from a compressed secp256k1 public key.
 pub(crate) fn create_address(
-    public_key: &CompressedPublicKey,
+    public_key: &[u8; 33],
     network: Network,
     address_type: AddressType,
-) -> Address {
-    let btc_network = network.to_bitcoin_network();
-
-    match address_type {
-        AddressType::P2pkh => Address::p2pkh(PublicKey::from(*public_key), btc_network),
-        AddressType::P2shP2wpkh => Address::p2shwpkh(public_key, btc_network),
-        AddressType::P2wpkh => Address::p2wpkh(public_key, btc_network),
-        AddressType::P2tr => {
-            let secp = Secp256k1::verification_only();
-            let internal_key = public_key.0.x_only_public_key().0;
-            Address::p2tr(&secp, internal_key, None, btc_network)
+) -> Result<String, DeriveError> {
+    match public_key.first().copied() {
+        Some(0x02 | 0x03) => {}
+        _ => {
+            return Err(DeriveError::Crypto(
+                "btc: expected compressed public key prefix 0x02 or 0x03".into(),
+            ));
         }
     }
+
+    match address_type {
+        AddressType::P2pkh => Ok(p2pkh(public_key, network)),
+        AddressType::P2shP2wpkh => Ok(p2sh_p2wpkh(public_key, network)),
+        AddressType::P2wpkh => p2wpkh(public_key, network),
+        AddressType::P2tr => p2tr(public_key, network),
+    }
+}
+
+fn hash160(data: &[u8]) -> [u8; 20] {
+    let sha = Sha256::digest(data);
+    let ripe = Ripemd160::digest(sha);
+    let mut out = [0u8; 20];
+    out.copy_from_slice(&ripe);
+    out
+}
+
+#[allow(
+    clippy::indexing_slicing,
+    reason = "fixed-size Base58Check fields are checked by construction"
+)]
+fn base58check(version: u8, payload_20: &[u8; 20]) -> String {
+    let mut buf = [0u8; 25];
+    buf[0] = version;
+    buf[1..21].copy_from_slice(payload_20);
+    let first = Sha256::digest(&buf[..21]);
+    let checksum = Sha256::digest(first);
+    buf[21..].copy_from_slice(&checksum[..4]);
+    bs58::encode(buf).into_string()
+}
+
+fn p2pkh(public_key: &[u8; 33], network: Network) -> String {
+    let version = match network {
+        Network::Mainnet => 0x00,
+        Network::Testnet => 0x6f,
+    };
+    base58check(version, &hash160(public_key))
+}
+
+fn p2sh_p2wpkh(public_key: &[u8; 33], network: Network) -> String {
+    let pubkey_hash = hash160(public_key);
+    // P2WPKH redeem script: OP_0 PUSH_20 <hash160(pubkey)>
+    let mut redeem = [0u8; 22];
+    redeem[0] = 0x00;
+    redeem[1] = 0x14;
+    redeem[2..].copy_from_slice(&pubkey_hash);
+
+    let version = match network {
+        Network::Mainnet => 0x05,
+        Network::Testnet => 0xc4,
+    };
+    base58check(version, &hash160(&redeem))
+}
+
+fn p2wpkh(public_key: &[u8; 33], network: Network) -> Result<String, DeriveError> {
+    let program = hash160(public_key);
+    let hrp = match network {
+        Network::Mainnet => bech32::hrp::BC,
+        Network::Testnet => bech32::hrp::TB,
+    };
+    bech32::segwit::encode_v0(hrp, &program)
+        .map_err(|e| DeriveError::AddressEncoding(format!("btc p2wpkh: {e}")))
+}
+
+/// Key-path-only P2TR (BIP-341).
+///
+/// Internal key: BIP-340 x-only (even-y lift).
+/// Output key: `Q = P + t·G`, then even-y normalized (`Q = -Q` if odd).
+/// This crate only encodes addresses; it does not sign or spend.
+fn p2tr(public_key: &[u8; 33], network: Network) -> Result<String, DeriveError> {
+    let mut even_key = *public_key;
+    even_key[0] = 0x02;
+    let internal = PublicKey::from_sec1_bytes(&even_key)
+        .map_err(|e| DeriveError::Crypto(format!("btc p2tr internal key: {e}")))?;
+    let internal_x = &even_key[1..];
+
+    let tag = Sha256::digest(b"TapTweak");
+    let mut hasher = Sha256::new();
+    hasher.update(tag);
+    hasher.update(tag);
+    hasher.update(internal_x);
+    let tweak_bytes: [u8; 32] = hasher.finalize().into();
+    let tweak = Option::<Scalar>::from(Scalar::from_repr(tweak_bytes.into())).ok_or_else(|| {
+        DeriveError::Crypto("btc p2tr: TapTweak not in secp256k1 scalar field".into())
+    })?;
+
+    let q_proj = ProjectivePoint::from(*internal.as_affine()) + ProjectivePoint::GENERATOR * tweak;
+    let mut affine = q_proj.to_affine();
+    let mut encoded = affine.to_encoded_point(true);
+    // x-only output key must be the even-y representative.
+    if encoded.as_bytes().first().copied() == Some(0x03) {
+        affine = (-ProjectivePoint::from(affine)).to_affine();
+        encoded = affine.to_encoded_point(true);
+    }
+    let output_x = encoded
+        .x()
+        .ok_or_else(|| DeriveError::Crypto("btc p2tr: output key at infinity".into()))?;
+
+    let hrp = match network {
+        Network::Mainnet => bech32::hrp::BC,
+        Network::Testnet => bech32::hrp::TB,
+    };
+    bech32::segwit::encode_v1(hrp, output_x)
+        .map_err(|e| DeriveError::AddressEncoding(format!("btc p2tr: {e}")))
 }
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::secp256k1::{Secp256k1, SecretKey};
-
     use super::*;
 
-    fn test_pubkey() -> CompressedPublicKey {
-        let secp = Secp256k1::new();
-        let sk = SecretKey::from_slice(
-            &hex::decode("4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318")
-                .unwrap(),
+    fn test_pubkey() -> [u8; 33] {
+        let mut pk = [0u8; 33];
+        hex::decode_to_slice(
+            "034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa",
+            &mut pk,
         )
         .unwrap();
-        let pk = bitcoin::PrivateKey::new(sk, bitcoin::Network::Bitcoin);
-        CompressedPublicKey::from_private_key(&secp, &pk).expect("valid key")
+        pk
     }
 
     #[test]
-    fn p2wpkh_starts_with_bc1q() {
-        let addr = create_address(&test_pubkey(), Network::Mainnet, AddressType::P2wpkh);
-        assert!(addr.to_string().starts_with("bc1q"));
+    fn rejects_uncompressed_prefix() {
+        let mut pk = test_pubkey();
+        pk[0] = 0x04;
+        assert!(matches!(
+            create_address(&pk, Network::Mainnet, AddressType::P2wpkh),
+            Err(DeriveError::Crypto(_))
+        ));
     }
 
     #[test]
-    fn p2pkh_starts_with_1() {
-        let addr = create_address(&test_pubkey(), Network::Mainnet, AddressType::P2pkh);
-        assert!(addr.to_string().starts_with('1'));
+    fn p2wpkh_mainnet_prefix() {
+        let a = create_address(&test_pubkey(), Network::Mainnet, AddressType::P2wpkh).unwrap();
+        assert!(a.starts_with("bc1q"));
     }
 
     #[test]
-    fn p2sh_starts_with_3() {
-        let addr = create_address(&test_pubkey(), Network::Mainnet, AddressType::P2shP2wpkh);
-        assert!(addr.to_string().starts_with('3'));
+    fn p2wpkh_testnet_prefix() {
+        let a = create_address(&test_pubkey(), Network::Testnet, AddressType::P2wpkh).unwrap();
+        assert!(a.starts_with("tb1q"));
     }
 
     #[test]
-    fn p2tr_starts_with_bc1p() {
-        let addr = create_address(&test_pubkey(), Network::Mainnet, AddressType::P2tr);
-        assert!(addr.to_string().starts_with("bc1p"));
+    fn p2pkh_mainnet_prefix() {
+        let a = create_address(&test_pubkey(), Network::Mainnet, AddressType::P2pkh).unwrap();
+        assert!(a.starts_with('1'));
     }
 
     #[test]
-    fn testnet_p2wpkh_starts_with_tb1q() {
-        let addr = create_address(&test_pubkey(), Network::Testnet, AddressType::P2wpkh);
-        assert!(addr.to_string().starts_with("tb1q"));
+    fn p2pkh_testnet_prefix() {
+        let a = create_address(&test_pubkey(), Network::Testnet, AddressType::P2pkh).unwrap();
+        assert!(matches!(a.chars().next(), Some('m' | 'n')));
+    }
+
+    #[test]
+    fn p2sh_mainnet_prefix() {
+        let a = create_address(&test_pubkey(), Network::Mainnet, AddressType::P2shP2wpkh).unwrap();
+        assert!(a.starts_with('3'));
+    }
+
+    #[test]
+    fn p2sh_testnet_prefix() {
+        let a = create_address(&test_pubkey(), Network::Testnet, AddressType::P2shP2wpkh).unwrap();
+        assert!(a.starts_with('2'));
+    }
+
+    #[test]
+    fn p2tr_mainnet_prefix() {
+        let a = create_address(&test_pubkey(), Network::Mainnet, AddressType::P2tr).unwrap();
+        assert!(a.starts_with("bc1p"));
+    }
+
+    #[test]
+    fn p2tr_testnet_prefix() {
+        let a = create_address(&test_pubkey(), Network::Testnet, AddressType::P2tr).unwrap();
+        assert!(a.starts_with("tb1p"));
     }
 }

--- a/crates/kobe-btc/src/deriver.rs
+++ b/crates/kobe-btc/src/deriver.rs
@@ -5,46 +5,26 @@ use alloc::{
     string::{String, ToString},
     vec::Vec,
 };
-use core::marker::PhantomData;
 use core::ops::Deref;
 
-use bitcoin::PrivateKey;
-use bitcoin::bip32::{ChildNumber, Xpriv};
-use bitcoin::key::CompressedPublicKey;
-use bitcoin::secp256k1::Secp256k1;
 use kobe_primitives::{
     Derive, DeriveError, DerivedAccount, DerivedPublicKey, Wallet, derive_range,
 };
 use zeroize::Zeroizing;
 
 use crate::address::create_address;
+use crate::wif::encode_wif;
 use crate::{AddressType, DerivationPath, Network};
 
 /// Bitcoin address deriver from a unified wallet seed.
-///
-/// This deriver takes a seed from [`kobe_primitives::Wallet`] and derives
-/// Bitcoin addresses following BIP32/44/49/84 standards.
 #[derive(Debug)]
 pub struct Deriver<'a> {
-    /// Master extended private key.
-    master_key: Xpriv,
-    /// Cached secp256k1 context (~768KB, reused across derivations).
-    secp: Secp256k1<bitcoin::secp256k1::All>,
-    /// Bitcoin network (mainnet or testnet).
+    wallet: &'a Wallet,
     network: Network,
-    /// Phantom data to track wallet lifetime.
-    _wallet: PhantomData<&'a Wallet>,
 }
 
-/// A Bitcoin-specific derived account — [`DerivedAccount`] plus chain-specific metadata.
-///
-/// Wraps the unified [`DerivedAccount`] (path, 32-byte private key, 33-byte
-/// compressed public key, address string) and adds Bitcoin-only fields:
-/// [`WIF`](Self::private_key_wif), [`AddressType`](Self::address_type), and
-/// the structured [`DerivationPath`](Self::bip32_path).
-///
-/// Implements `Deref<Target = DerivedAccount>`, so all shared accessors
-/// (`address()`, `public_key_bytes()`, etc.) are available directly.
+/// Bitcoin-specific derived account: unified [`DerivedAccount`] plus WIF,
+/// address type, and structured path.
 #[derive(Debug, Clone)]
 pub struct BtcAccount {
     inner: DerivedAccount,
@@ -54,39 +34,35 @@ pub struct BtcAccount {
 }
 
 impl BtcAccount {
-    /// Private key in WIF (Wallet Import Format), zeroized on drop.
+    /// Private key in WIF, zeroized on drop.
     #[inline]
     #[must_use]
     pub const fn private_key_wif(&self) -> &Zeroizing<String> {
         &self.private_key_wif
     }
 
-    /// The [`AddressType`] used to derive this account.
+    /// Address type used for this account.
     #[inline]
     #[must_use]
     pub const fn address_type(&self) -> AddressType {
         self.address_type
     }
 
-    /// Structured BIP-32 derivation path.
-    ///
-    /// Access the string form via [`DerivedAccount::path`] (inherited
-    /// through [`Deref<Target = DerivedAccount>`][Self::deref]).
+    /// Structured BIP-32 path.
     #[inline]
     #[must_use]
     pub const fn bip32_path(&self) -> &DerivationPath {
         &self.bip32_path
     }
 
-    /// The underlying unified [`DerivedAccount`].
+    /// Borrow the unified account.
     #[inline]
     #[must_use]
     pub const fn as_derived_account(&self) -> &DerivedAccount {
         &self.inner
     }
 
-    /// Consume and yield the underlying [`DerivedAccount`], dropping
-    /// Bitcoin-specific metadata.
+    /// Consume into the unified account.
     #[inline]
     #[must_use]
     pub fn into_derived_account(self) -> DerivedAccount {
@@ -110,48 +86,42 @@ impl From<BtcAccount> for DerivedAccount {
     }
 }
 
+impl AsRef<DerivedAccount> for BtcAccount {
+    #[inline]
+    fn as_ref(&self) -> &DerivedAccount {
+        &self.inner
+    }
+}
+
 impl<'a> Deriver<'a> {
-    /// Create a new Bitcoin deriver from a wallet.
+    /// Create a deriver. Key material is not derived until a `derive_*` call.
+    ///
+    /// Currently infallible. `Result` is kept so call sites match other chain
+    /// crates (`Deriver::new(...)?`).
     ///
     /// # Errors
     ///
-    /// Returns an error if the master key derivation fails.
+    /// Reserved for future fallible initialization; today this always returns `Ok`.
     #[inline]
-    pub fn new(wallet: &'a Wallet, network: Network) -> Result<Self, DeriveError> {
-        let master_key = Xpriv::new_master(network.to_bitcoin_network(), wallet.seed().as_slice())
-            .map_err(|e| DeriveError::Crypto(alloc::format!("bitcoin bip32 master: {e}")))?;
-
-        Ok(Self {
-            master_key,
-            secp: Secp256k1::new(),
-            network,
-            _wallet: PhantomData,
-        })
+    pub const fn new(wallet: &'a Wallet, network: Network) -> Result<Self, DeriveError> {
+        Ok(Self { wallet, network })
     }
 
-    /// Derive a Bitcoin account using P2WPKH (Native `SegWit`) by default.
-    ///
-    /// Uses path: `m/84'/0'/0'/0/{index}` for mainnet.
+    /// Default: P2WPKH at BIP-84.
     ///
     /// # Errors
     ///
-    /// Returns an error if derivation fails.
+    /// Returns an error if path, key, address, or WIF derivation fails.
     #[inline]
     pub fn derive(&self, index: u32) -> Result<BtcAccount, DeriveError> {
         self.derive_with(AddressType::P2wpkh, index)
     }
 
-    /// Derive a Bitcoin account with a specific [`AddressType`].
-    ///
-    /// This method supports all four Bitcoin address formats:
-    /// - **P2pkh** (Legacy): `m/44'/coin'/0'/0/{index}`
-    /// - **`P2shP2wpkh`** (Nested SegWit): `m/49'/coin'/0'/0/{index}`
-    /// - **P2wpkh** (Native SegWit): `m/84'/coin'/0'/0/{index}`
-    /// - **P2tr** (Taproot): `m/86'/coin'/0'/0/{index}`
+    /// Derive with an explicit address type (standard purpose path).
     ///
     /// # Errors
     ///
-    /// Returns an error if derivation fails.
+    /// Returns an error if path, key, address, or WIF derivation fails.
     #[inline]
     pub fn derive_with(
         &self,
@@ -162,11 +132,11 @@ impl<'a> Deriver<'a> {
         self.derive_structured(&path, address_type)
     }
 
-    /// Derive multiple accounts with a specific [`AddressType`].
+    /// Derive a contiguous index range.
     ///
     /// # Errors
     ///
-    /// Returns an error if any derivation fails.
+    /// Returns an error if the range is invalid or any account derivation fails.
     pub fn derive_many_with(
         &self,
         address_type: AddressType,
@@ -176,25 +146,16 @@ impl<'a> Deriver<'a> {
         derive_range(start, count, |i| self.derive_with(address_type, i))
     }
 
-    /// Derive a [`BtcAccount`] at a string BIP-32 path, inferring the
-    /// [`AddressType`] from the path's BIP-44 purpose segment.
-    ///
-    /// Aligned with every other chain's `derive_at(&str)` entry point.
-    /// The purpose → type mapping follows [`AddressType::from_purpose`]:
-    /// `44' → P2PKH`, `49' → P2SH-P2WPKH`, `84' → P2WPKH`, `86' → P2TR`.
-    /// For any other purpose (or a non-hardened first segment) use
-    /// [`derive_at_with`](Self::derive_at_with) with an explicit type.
+    /// Derive at a path string; infer [`AddressType`] from purpose.
     ///
     /// # Errors
     ///
-    /// Returns [`DeriveError::Path`] if the path is malformed or its
-    /// purpose does not map to a standard BIP, or [`DeriveError::Crypto`]
-    /// if BIP-32 derivation fails.
+    /// Returns an error if the path is invalid or account derivation fails.
     pub fn derive_at(&self, path: &str) -> Result<BtcAccount, DeriveError> {
         let parsed = DerivationPath::from_path_str(path)?;
         let address_type = infer_address_type(&parsed).ok_or_else(|| {
             DeriveError::Path(alloc::format!(
-                "bitcoin: cannot infer address type from path '{path}'; \
+                "btc: cannot infer address type from path '{path}'; \
                  purpose must be 44'/49'/84'/86'. \
                  Use Deriver::derive_at_with(path, address_type) for custom paths."
             ))
@@ -202,17 +163,11 @@ impl<'a> Deriver<'a> {
         self.derive_structured(&parsed, address_type)
     }
 
-    /// Derive a [`BtcAccount`] at a string BIP-32 path with an explicit
-    /// [`AddressType`].
-    ///
-    /// Escape hatch for non-standard paths (custom purpose, non-hardened
-    /// first segment) that [`derive_at`](Self::derive_at) cannot classify
-    /// on its own.
+    /// Derive at a path with an explicit address type (non-standard paths).
     ///
     /// # Errors
     ///
-    /// Returns [`DeriveError::Path`] if the path is malformed, or
-    /// [`DeriveError::Crypto`] if BIP-32 derivation fails.
+    /// Returns an error if the path is invalid or account derivation fails.
     pub fn derive_at_with(
         &self,
         path: &str,
@@ -222,53 +177,42 @@ impl<'a> Deriver<'a> {
         self.derive_structured(&parsed, address_type)
     }
 
-    /// Derive a [`BtcAccount`] at a pre-parsed [`DerivationPath`] with the
-    /// requested [`AddressType`].
-    ///
-    /// Advanced entry point for callers that already hold a structured
-    /// path (for instance after validating it once and reusing it across
-    /// many derivations); every other `derive_*` method funnels through
-    /// here. Most callers want [`derive_at`](Self::derive_at) or
-    /// [`derive_at_with`](Self::derive_at_with) instead.
+    /// Low-level entry: pre-parsed path + address type.
     ///
     /// # Errors
     ///
-    /// Returns [`DeriveError::Crypto`] if BIP-32 derivation fails.
+    /// Returns an error if key, address, or WIF derivation fails.
     pub fn derive_structured(
         &self,
         path: &DerivationPath,
         address_type: AddressType,
     ) -> Result<BtcAccount, DeriveError> {
-        let derived = self
-            .master_key
-            .derive_priv(&self.secp, path.inner())
-            .map_err(|e| DeriveError::Crypto(alloc::format!("bitcoin bip32 derive: {e}")))?;
+        let path_string = path.to_string();
+        let derived = self.wallet.derive_secp256k1(&path_string)?;
 
-        let private_key = PrivateKey::new(derived.private_key, self.network.to_bitcoin_network());
-        let public_key = CompressedPublicKey::from_private_key(&self.secp, &private_key)
-            .map_err(|e| DeriveError::Crypto(alloc::format!("bitcoin secp256k1: {e}")))?;
+        // Secrets remain Zeroizing end-to-end.
+        let sk = derived.private_key_bytes();
+        let pk = derived.compressed_pubkey();
 
-        let address = create_address(&public_key, self.network, address_type);
-
-        let sk_bytes = Zeroizing::new(derived.private_key.secret_bytes());
-        let pk_bytes: [u8; 33] = public_key.to_bytes();
+        let address = create_address(&pk, self.network, address_type)?;
+        let private_key_wif = encode_wif(&sk, self.network)?;
 
         let inner = DerivedAccount::new(
-            path.to_string(),
-            sk_bytes,
-            DerivedPublicKey::Secp256k1Compressed(pk_bytes),
-            address.to_string(),
+            path_string,
+            sk,
+            DerivedPublicKey::Secp256k1Compressed(pk),
+            address,
         );
 
         Ok(BtcAccount {
             inner,
-            private_key_wif: Zeroizing::new(private_key.to_wif()),
+            private_key_wif,
             address_type,
             bip32_path: path.clone(),
         })
     }
 
-    /// Get the network.
+    /// Network this deriver was created with.
     #[must_use]
     pub const fn network(&self) -> Network {
         self.network
@@ -283,47 +227,27 @@ impl Derive for Deriver<'_> {
         self.derive_with(AddressType::P2wpkh, index)
     }
 
-    /// Forwards to [`Deriver::derive_at`].
-    ///
-    /// See that method for the purpose → [`AddressType`] mapping and the
-    /// non-standard-path escape hatch
-    /// ([`derive_at_with`](Deriver::derive_at_with)).
     fn derive_path(&self, path: &str) -> Result<BtcAccount, DeriveError> {
         self.derive_at(path)
     }
 }
 
-/// Infer the [`AddressType`] from the BIP-44 purpose segment of `path`.
-///
-/// Returns `None` if the path is empty, its first segment is non-hardened,
-/// or the hardened value does not map to a standard BIP purpose.
 fn infer_address_type(path: &DerivationPath) -> Option<AddressType> {
-    let first = path.inner().into_iter().next()?;
-    match first {
-        ChildNumber::Hardened { index } => AddressType::from_purpose(*index),
-        ChildNumber::Normal { .. } => None,
-    }
-}
-
-impl AsRef<DerivedAccount> for BtcAccount {
-    #[inline]
-    fn as_ref(&self) -> &DerivedAccount {
-        &self.inner
+    let first = path.inner().iter().next()?;
+    if first.is_hardened() {
+        AddressType::from_purpose(first.index())
+    } else {
+        None
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::PrivateKey;
     use kobe_primitives::DeriveExt;
 
     use super::*;
+    use crate::wif::decode_wif;
 
-    /// Canonical BIP-39 test mnemonic (12 × `abandon` + `about`).
-    ///
-    /// Mnemonic and derived addresses appear on iancoleman.io/bip39, every
-    /// hardware wallet vendor test, and the official BIP-84 / BIP-86 test
-    /// vectors, so any regression will be immediately obvious to users.
     const TEST_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
     fn test_wallet() -> Wallet {
@@ -334,14 +258,25 @@ mod tests {
         Deriver::new(wallet, network).unwrap()
     }
 
-    /// BIP-84 (`m/84'/0'/0'/0/{i}`) → native-`SegWit` `bc1q…` addresses.
-    /// Cross-verified against `bitcoinjs-lib@p2wpkh` in an independent
-    /// Node.js pipeline, matching the BIP-84 test vectors listed at
-    /// <https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki>.
+    #[test]
+    fn derived_key_bytes_match_bip84_vector() {
+        let wallet = test_wallet();
+        let d = deriver(&wallet, Network::Mainnet);
+        let account = d.derive_at("m/84'/0'/0'/0/0").unwrap();
+        assert_eq!(
+            account.private_key_hex().as_str(),
+            "4604b4b710fe91f584fff084e1a9159fe4f8408fff380596a604948474ce4fa3"
+        );
+        assert_eq!(
+            account.public_key_hex(),
+            "0330d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c"
+        );
+    }
+
     #[test]
     fn kat_bip84_p2wpkh_abandon_index0() {
-        let w = test_wallet();
-        let a = deriver(&w, Network::Mainnet)
+        let wallet = test_wallet();
+        let a = deriver(&wallet, Network::Mainnet)
             .derive_with(AddressType::P2wpkh, 0)
             .unwrap();
         assert_eq!(a.path(), "m/84'/0'/0'/0/0");
@@ -355,42 +290,38 @@ mod tests {
 
     #[test]
     fn kat_bip84_p2wpkh_abandon_index1() {
-        let w = test_wallet();
-        let a = deriver(&w, Network::Mainnet)
+        let wallet = test_wallet();
+        let a = deriver(&wallet, Network::Mainnet)
             .derive_with(AddressType::P2wpkh, 1)
             .unwrap();
         assert_eq!(a.path(), "m/84'/0'/0'/0/1");
         assert_eq!(a.address(), "bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g");
     }
 
-    /// BIP-44 (`m/44'/0'/0'/0/{i}`) → legacy P2PKH `1…` addresses.
     #[test]
     fn kat_bip44_p2pkh_abandon_index0() {
-        let w = test_wallet();
-        let a = deriver(&w, Network::Mainnet)
+        let wallet = test_wallet();
+        let a = deriver(&wallet, Network::Mainnet)
             .derive_with(AddressType::P2pkh, 0)
             .unwrap();
         assert_eq!(a.path(), "m/44'/0'/0'/0/0");
         assert_eq!(a.address(), "1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA");
     }
 
-    /// BIP-49 (`m/49'/0'/0'/0/{i}`) → P2SH-wrapped `SegWit` `3…` addresses.
     #[test]
     fn kat_bip49_p2sh_p2wpkh_abandon_index0() {
-        let w = test_wallet();
-        let a = deriver(&w, Network::Mainnet)
+        let wallet = test_wallet();
+        let a = deriver(&wallet, Network::Mainnet)
             .derive_with(AddressType::P2shP2wpkh, 0)
             .unwrap();
         assert_eq!(a.path(), "m/49'/0'/0'/0/0");
         assert_eq!(a.address(), "37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf");
     }
 
-    /// BIP-86 (`m/86'/0'/0'/0/{i}`) → single-key Taproot `bc1p…`
-    /// addresses. Cross-verified against `bitcoinjs-lib@p2tr`.
     #[test]
     fn kat_bip86_p2tr_abandon_index0() {
-        let w = test_wallet();
-        let a = deriver(&w, Network::Mainnet)
+        let wallet = test_wallet();
+        let a = deriver(&wallet, Network::Mainnet)
             .derive_with(AddressType::P2tr, 0)
             .unwrap();
         assert_eq!(a.path(), "m/86'/0'/0'/0/0");
@@ -400,35 +331,65 @@ mod tests {
         );
     }
 
-    /// Testnet SLIP-44 coin type `1` + BIP-84 bech32 HRP `tb`.
-    /// Cross-verified against `bitcoinjs-lib` on `bitcoin.networks.testnet`.
+    #[test]
+    fn kat_testnet_p2pkh_abandon_index0() {
+        let wallet = test_wallet();
+        let a = deriver(&wallet, Network::Testnet)
+            .derive_with(AddressType::P2pkh, 0)
+            .unwrap();
+        assert_eq!(a.path(), "m/44'/1'/0'/0/0");
+        assert_eq!(a.address(), "mkpZhYtJu2r87Js3pDiWJDmPte2NRZ8bJV");
+    }
+
+    /// BIP-49 testnet vector:
+    /// <https://github.com/bitcoin/bips/blob/master/bip-0049.mediawiki>
+    #[test]
+    fn kat_testnet_p2sh_p2wpkh_abandon_index0() {
+        let wallet = test_wallet();
+        let a = deriver(&wallet, Network::Testnet)
+            .derive_with(AddressType::P2shP2wpkh, 0)
+            .unwrap();
+        assert_eq!(a.path(), "m/49'/1'/0'/0/0");
+        assert_eq!(a.address(), "2Mww8dCYPUpKHofjgcXcBCEGmniw9CoaiD2");
+    }
+
     #[test]
     fn kat_testnet_p2wpkh_abandon_index0() {
-        let w = test_wallet();
-        let a = deriver(&w, Network::Testnet)
+        let wallet = test_wallet();
+        let a = deriver(&wallet, Network::Testnet)
             .derive_with(AddressType::P2wpkh, 0)
             .unwrap();
         assert_eq!(a.path(), "m/84'/1'/0'/0/0");
         assert_eq!(a.address(), "tb1q6rz28mcfaxtmd6v789l9rrlrusdprr9pqcpvkl");
     }
 
-    /// `Derive::derive` (the trait) and `Deriver::derive` (inherent) must
-    /// both route to P2WPKH with BIP-84 paths.
+    #[test]
+    fn kat_testnet_p2tr_abandon_index0() {
+        let wallet = test_wallet();
+        let a = deriver(&wallet, Network::Testnet)
+            .derive_with(AddressType::P2tr, 0)
+            .unwrap();
+        assert_eq!(a.path(), "m/86'/1'/0'/0/0");
+        assert_eq!(
+            a.address(),
+            "tb1p8wpt9v4frpf3tkn0srd97pksgsxc5hs52lafxwru9kgeephvs7rqlqt9zj"
+        );
+    }
+
     #[test]
     fn default_derive_uses_bip84_p2wpkh() {
-        let w = test_wallet();
-        let d = deriver(&w, Network::Mainnet);
+        let wallet = test_wallet();
+        let d = deriver(&wallet, Network::Mainnet);
         let def = d.derive(0).unwrap();
         let explicit = d.derive_with(AddressType::P2wpkh, 0).unwrap();
         assert_eq!(def.address(), explicit.address());
         assert_eq!(def.path(), explicit.path());
     }
 
-    /// `derive_many` must agree with scalar `derive_with` for every index.
     #[test]
     fn derive_many_matches_individual() {
-        let w = test_wallet();
-        let d = deriver(&w, Network::Mainnet);
+        let wallet = test_wallet();
+        let d = deriver(&wallet, Network::Mainnet);
         let batch = d.derive_many(0, 5).unwrap();
         let single: Vec<_> = (0..5)
             .map(|i| d.derive_with(AddressType::P2wpkh, i).unwrap())
@@ -439,38 +400,44 @@ mod tests {
         }
     }
 
-    /// WIF must round-trip back to the same 32-byte private key — guards
-    /// against checksum or version-byte errors in the WIF encoder.
     #[test]
     fn wif_roundtrips_to_private_key_bytes() {
-        let w = test_wallet();
-        let a = deriver(&w, Network::Mainnet).derive(0).unwrap();
-        let pk = PrivateKey::from_wif(a.private_key_wif().as_str()).unwrap();
-        assert_eq!(&pk.to_bytes(), a.private_key_bytes().as_slice());
-        assert_eq!(pk.network, bitcoin::NetworkKind::Main);
+        let wallet = test_wallet();
+        let a = deriver(&wallet, Network::Mainnet).derive(0).unwrap();
+        let (key, network) = decode_wif(a.private_key_wif().as_str()).unwrap();
+        assert_eq!(key.as_ref(), a.private_key_bytes().as_ref());
+        assert_eq!(network, Network::Mainnet);
+    }
+
+    #[test]
+    fn wif_roundtrips_testnet_private_key_bytes() {
+        let wallet = test_wallet();
+        let a = deriver(&wallet, Network::Testnet).derive(0).unwrap();
+        let (key, network) = decode_wif(a.private_key_wif().as_str()).unwrap();
+        assert_eq!(key.as_ref(), a.private_key_bytes().as_ref());
+        assert_eq!(network, Network::Testnet);
     }
 
     #[test]
     fn passphrase_changes_derivation() {
-        let w = Wallet::from_mnemonic(TEST_MNEMONIC, Some("TREZOR")).unwrap();
+        let wallet = test_wallet();
+        let with_pass = Wallet::from_mnemonic(TEST_MNEMONIC, Some("TREZOR")).unwrap();
         assert_ne!(
-            deriver(&test_wallet(), Network::Mainnet)
+            deriver(&wallet, Network::Mainnet)
                 .derive(0)
                 .unwrap()
                 .address(),
-            deriver(&w, Network::Mainnet).derive(0).unwrap().address(),
+            deriver(&with_pass, Network::Mainnet)
+                .derive(0)
+                .unwrap()
+                .address(),
         );
     }
 
-    /// `Derive::derive_path` must infer the [`AddressType`] from the purpose
-    /// segment so that `m/44'` → P2PKH, `m/49'` → P2SH-P2WPKH, `m/84'` → P2WPKH,
-    /// and `m/86'` → P2TR on the canonical `abandon…about` mnemonic. Regression
-    /// test against the previous hard-coded P2WPKH behaviour, which produced
-    /// `bc1q…` for BIP-44/49/86 paths and silently misrepresented user intent.
     #[test]
     fn derive_path_infers_address_type_from_purpose() {
-        let w = test_wallet();
-        let d = deriver(&w, Network::Mainnet);
+        let wallet = test_wallet();
+        let d = deriver(&wallet, Network::Mainnet);
 
         let legacy = d.derive_path("m/44'/0'/0'/0/0").unwrap();
         assert_eq!(legacy.address_type(), AddressType::P2pkh);
@@ -489,71 +456,44 @@ mod tests {
         assert!(taproot.address().starts_with("bc1p"));
     }
 
-    /// Non-standard paths (unknown purpose or non-hardened first segment)
-    /// must surface a [`DeriveError::Path`] that points callers at
-    /// [`Deriver::derive_at_with`], rather than silently defaulting to
-    /// P2WPKH.
     #[test]
     fn derive_path_rejects_non_standard_purpose() {
-        let w = test_wallet();
-        let d = deriver(&w, Network::Mainnet);
+        let wallet = test_wallet();
+        let d = deriver(&wallet, Network::Mainnet);
 
-        let unknown_purpose_err = d.derive_path("m/1'/2'/3'").unwrap_err();
-        let DeriveError::Path(msg) = &unknown_purpose_err else {
-            unreachable!("expected DeriveError::Path, got {unknown_purpose_err:?}");
-        };
-        assert!(
-            msg.contains("cannot infer address type"),
-            "unexpected error message: {msg}"
-        );
-        assert!(
-            msg.contains("derive_at_with"),
-            "error must point users at Deriver::derive_at_with: {msg}"
-        );
+        let err = d.derive_path("m/1'/2'/3'").unwrap_err();
+        assert!(matches!(err, DeriveError::Path(_)));
+        if let DeriveError::Path(msg) = &err {
+            assert!(msg.contains("cannot infer address type"));
+            assert!(msg.contains("derive_at_with"));
+        }
 
         let non_hardened_err = d.derive_path("m/44/0'/0'/0/0").unwrap_err();
-        let DeriveError::Path(_) = &non_hardened_err else {
-            unreachable!(
-                "non-hardened purpose must fail with Path error, got {non_hardened_err:?}"
-            );
-        };
+        assert!(matches!(non_hardened_err, DeriveError::Path(_)));
     }
 
-    /// `derive_at` mirrors `Derive::derive_path` — sanity-check they agree
-    /// byte-for-byte on every BIP purpose, so downstream code can pick
-    /// either entry point without behavioural drift.
     #[test]
     fn derive_at_matches_trait_derive_path() {
-        let w = test_wallet();
-        let d = deriver(&w, Network::Mainnet);
+        let wallet = test_wallet();
+        let d = deriver(&wallet, Network::Mainnet);
         for path in [
             "m/44'/0'/0'/0/0",
             "m/49'/0'/0'/0/0",
             "m/84'/0'/0'/0/0",
             "m/86'/0'/0'/0/0",
         ] {
-            let trait_acct = d.derive_path(path).unwrap();
-            let inherent_acct = d.derive_at(path).unwrap();
-            assert_eq!(trait_acct.address(), inherent_acct.address(), "path={path}");
-            assert_eq!(
-                trait_acct.address_type(),
-                inherent_acct.address_type(),
-                "path={path}",
-            );
+            let a = d.derive_path(path).unwrap();
+            let b = d.derive_at(path).unwrap();
+            assert_eq!(a.address(), b.address());
+            assert_eq!(a.address_type(), b.address_type());
         }
     }
 
-    /// `derive_at_with` is the escape hatch for non-standard paths and
-    /// must succeed where `derive_at` would reject the purpose. We also
-    /// check that the requested `AddressType` overrides any inference —
-    /// here we ask for P2TR at a BIP-84 path on purpose.
     #[test]
     fn derive_at_with_accepts_non_standard_purpose() {
-        let w = test_wallet();
-        let d = deriver(&w, Network::Mainnet);
+        let wallet = test_wallet();
+        let d = deriver(&wallet, Network::Mainnet);
 
-        // Non-standard purpose 7' — `derive_at` can't classify it, but
-        // `derive_at_with` must work with an explicit AddressType.
         let acct = d
             .derive_at_with("m/7'/0'/0'/0/0", AddressType::P2wpkh)
             .unwrap();
@@ -561,8 +501,6 @@ mod tests {
         assert_eq!(acct.address_type(), AddressType::P2wpkh);
         assert!(acct.address().starts_with("bc1q"));
 
-        // Explicit AddressType must override the purpose hint on a
-        // standard path too (BIP-84 path → P2TR if the caller insists).
         let override_acct = d
             .derive_at_with("m/84'/0'/0'/0/0", AddressType::P2tr)
             .unwrap();
@@ -570,18 +508,15 @@ mod tests {
         assert!(override_acct.address().starts_with("bc1p"));
     }
 
-    /// `derive_structured` is the low-level entry point; when fed a
-    /// pre-parsed path it must produce the same account as
-    /// `derive_at_with` given the same string.
     #[test]
     fn derive_structured_matches_derive_at_with() {
-        let w = test_wallet();
-        let d = deriver(&w, Network::Mainnet);
+        let wallet = test_wallet();
+        let d = deriver(&wallet, Network::Mainnet);
         let path_str = "m/84'/0'/0'/0/0";
         let parsed = DerivationPath::from_path_str(path_str).unwrap();
-        let structured = d.derive_structured(&parsed, AddressType::P2wpkh).unwrap();
-        let at_with = d.derive_at_with(path_str, AddressType::P2wpkh).unwrap();
-        assert_eq!(structured.address(), at_with.address());
-        assert_eq!(structured.path(), at_with.path());
+        let a = d.derive_structured(&parsed, AddressType::P2wpkh).unwrap();
+        let b = d.derive_at_with(path_str, AddressType::P2wpkh).unwrap();
+        assert_eq!(a.address(), b.address());
+        assert_eq!(a.path(), b.path());
     }
 }

--- a/crates/kobe-btc/src/lib.rs
+++ b/crates/kobe-btc/src/lib.rs
@@ -2,25 +2,22 @@
 //!
 //! Derives Bitcoin addresses from a [`kobe_primitives::Wallet`] seed following
 //! BIP-32/44/49/84/86. Supports P2PKH, P2SH-P2WPKH, P2WPKH, and P2TR
-//! address types across mainnet and testnet.
+//! across mainnet and testnet.
 //!
-//! # Architectural note: why `kobe-btc` does not use `kobe_primitives::bip32`
+//! # Architecture
 //!
-//! Every other secp256k1 chain in the workspace derives keys through
-//! [`kobe_primitives::Wallet::derive_secp256k1`] (backed by the `bip32`
-//! crate). `kobe-btc` is the sole exception: it builds a
-//! [`bitcoin::bip32::Xpriv`] directly from
-//! [`kobe_primitives::Wallet::seed`] so the entire pipeline —
-//! [`bitcoin::PrivateKey::to_wif`], [`bitcoin::key::CompressedPublicKey`],
-//! the native [`bitcoin::Address`] enum, and the BIP-44/49/84/86 path
-//! constants — stays inside the `bitcoin` crate's type system.
+//! - Key derivation: [`kobe_primitives::Wallet::derive_secp256k1`] (shared pipeline).
+//! - Address and WIF: implemented in this crate and pinned by KATs
+//!   (BIP-44/49/84/86; BIP-49 testnet official vectors; bitcoinjs-lib where noted).
+//! - The workspace prefers thin wrappers around mature libraries; `kobe-btc`
+//!   intentionally drops the `bitcoin` crate dependency while keeping the same
+//!   derived address strings and WIF encoding.
 //!
-//! The two BIP-32 implementations are held to the same test vectors (see
-//! the `kat_bip84_*`, `kat_bip49_*`, `kat_bip86_*`, and `wif_roundtrips_*`
-//! tests), so users never observe the divergence. If you need to unify on a
-//! single secp256k1 pipeline, note that giving up Bitcoin's native
-//! `Address` / WIF layer would require re-implementing every Bitcoin
-//! address encoding by hand — a net negative for maintenance and audit.
+//! # Taproot scope
+//!
+//! Supported: single-key, key-path-only P2TR (BIP-86 style).
+//! Not supported: script trees, merkle roots, `MuSig`, signing, or spending.
+//! Output keys are even-y normalized; addresses match BIP-86 mainnet KATs.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -33,6 +30,8 @@ mod address;
 mod deriver;
 mod network;
 mod types;
+#[cfg(feature = "alloc")]
+mod wif;
 
 #[cfg(feature = "alloc")]
 pub use deriver::{BtcAccount, Deriver};

--- a/crates/kobe-btc/src/network.rs
+++ b/crates/kobe-btc/src/network.rs
@@ -3,8 +3,6 @@
 use core::fmt;
 use core::str::FromStr;
 
-use bitcoin::Network as BtcNetwork;
-
 /// Supported Bitcoin networks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
 #[non_exhaustive]
@@ -17,17 +15,7 @@ pub enum Network {
 }
 
 impl Network {
-    /// Convert to bitcoin crate's Network type.
-    #[inline]
-    #[must_use]
-    pub const fn to_bitcoin_network(self) -> BtcNetwork {
-        match self {
-            Self::Mainnet => BtcNetwork::Bitcoin,
-            Self::Testnet => BtcNetwork::Testnet,
-        }
-    }
-
-    /// Get the BIP44 coin type for this network.
+    /// BIP-44 coin type for this network.
     #[inline]
     #[must_use]
     pub const fn coin_type(self) -> u32 {
@@ -37,7 +25,7 @@ impl Network {
         }
     }
 
-    /// Get network name as string.
+    /// Stable name for display / config.
     #[inline]
     #[must_use]
     pub const fn name(self) -> &'static str {
@@ -50,7 +38,7 @@ impl Network {
 
 impl fmt::Display for Network {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.name())
+        f.write_str(self.name())
     }
 }
 
@@ -61,7 +49,7 @@ pub struct ParseNetworkError;
 
 impl fmt::Display for ParseNetworkError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "invalid network, expected: mainnet or testnet")
+        f.write_str("invalid network, expected: mainnet or testnet")
     }
 }
 
@@ -73,7 +61,7 @@ impl FromStr for Network {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "mainnet" | "main" | "bitcoin" => Ok(Self::Mainnet),
+            "mainnet" | "main" => Ok(Self::Mainnet),
             "testnet" | "test" | "testnet3" | "testnet4" => Ok(Self::Testnet),
             _ => Err(ParseNetworkError),
         }
@@ -85,39 +73,38 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_network_from_str() {
+    fn network_from_str() {
         assert_eq!("mainnet".parse::<Network>().unwrap(), Network::Mainnet);
         assert_eq!("main".parse::<Network>().unwrap(), Network::Mainnet);
-        assert_eq!("bitcoin".parse::<Network>().unwrap(), Network::Mainnet);
         assert_eq!("testnet".parse::<Network>().unwrap(), Network::Testnet);
         assert_eq!("test".parse::<Network>().unwrap(), Network::Testnet);
     }
 
     #[test]
-    fn test_network_from_str_case_insensitive() {
+    fn network_from_str_case_insensitive() {
         assert_eq!("MAINNET".parse::<Network>().unwrap(), Network::Mainnet);
         assert_eq!("TESTNET".parse::<Network>().unwrap(), Network::Testnet);
     }
 
     #[test]
-    fn test_network_from_str_invalid() {
+    fn network_from_str_invalid() {
         assert!("invalid".parse::<Network>().is_err());
         assert!("".parse::<Network>().is_err());
     }
 
     #[test]
-    fn test_network_coin_type() {
+    fn network_coin_type() {
         assert_eq!(Network::Mainnet.coin_type(), 0);
         assert_eq!(Network::Testnet.coin_type(), 1);
     }
 
     #[test]
-    fn test_network_default() {
+    fn network_default() {
         assert_eq!(Network::default(), Network::Mainnet);
     }
 
     #[test]
-    fn test_network_display() {
+    fn network_display() {
         assert_eq!(Network::Mainnet.to_string(), "mainnet");
         assert_eq!(Network::Testnet.to_string(), "testnet");
     }

--- a/crates/kobe-btc/src/types.rs
+++ b/crates/kobe-btc/src/types.rs
@@ -15,19 +15,19 @@ use crate::Network;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum AddressType {
-    /// Pay to Public Key Hash (Legacy) - starts with 1 or m/n
+    /// Pay to Public Key Hash (Legacy) — `1…` / `m…`/`n…`
     P2pkh,
-    /// Pay to Script Hash wrapping P2WPKH (`SegWit` compatible) - starts with 3 or 2
+    /// Pay to Script Hash wrapping P2WPKH (Nested `SegWit`) — `3…` / `2…`
     P2shP2wpkh,
-    /// Pay to Witness Public Key Hash (Native `SegWit`) - starts with bc1q or tb1q
+    /// Pay to Witness Public Key Hash (Native `SegWit`) — `bc1q…` / `tb1q…`
     #[default]
     P2wpkh,
-    /// Pay to Taproot (Taproot/SegWit v1) - starts with bc1p or tb1p
+    /// Pay to Taproot — `bc1p…` / `tb1p…`
     P2tr,
 }
 
 impl AddressType {
-    /// Get the BIP purpose for this address type.
+    /// BIP purpose for this address type.
     #[inline]
     #[must_use]
     pub const fn purpose(self) -> u32 {
@@ -39,10 +39,7 @@ impl AddressType {
         }
     }
 
-    /// Infer the address type from a BIP-44 / 49 / 84 / 86 `purpose` index.
-    ///
-    /// Returns `None` for any `purpose` that is not a standard BIP purpose.
-    /// This is the inverse of [`AddressType::purpose`].
+    /// Inverse of [`AddressType::purpose`].
     #[inline]
     #[must_use]
     pub const fn from_purpose(purpose: u32) -> Option<Self> {
@@ -55,7 +52,7 @@ impl AddressType {
         }
     }
 
-    /// Get address type name.
+    /// Human-readable name.
     #[inline]
     #[must_use]
     pub const fn name(self) -> &'static str {
@@ -70,7 +67,7 @@ impl AddressType {
 
 impl fmt::Display for AddressType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.name())
+        f.write_str(self.name())
     }
 }
 
@@ -81,10 +78,7 @@ pub struct ParseAddressTypeError;
 
 impl fmt::Display for ParseAddressTypeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "invalid address type, expected: p2pkh, p2sh, p2wpkh, or p2tr"
-        )
+        f.write_str("invalid address type, expected: p2pkh, p2sh, p2wpkh, or p2tr")
     }
 }
 
@@ -105,23 +99,20 @@ impl FromStr for AddressType {
     }
 }
 
-/// BIP32 derivation path.
+/// BIP-32 derivation path with a stable `m/…` string form.
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DerivationPath {
-    /// Wrapped BIP-32 derivation path.
-    inner: bitcoin::bip32::DerivationPath,
+    inner: bip32::DerivationPath,
 }
 
 #[cfg(feature = "alloc")]
 impl DerivationPath {
-    /// Create a BIP44/49/84 standard path.
-    ///
-    /// Format: `m/purpose'/coin_type'/account'/change/address_index`
+    /// Standard path: `m/purpose'/coin_type'/account'/change/index`.
     ///
     /// # Errors
     ///
-    /// Returns an error if the path string cannot be parsed.
+    /// Returns [`DeriveError::Path`] if the generated path is invalid.
     pub fn bip_standard(
         address_type: AddressType,
         network: Network,
@@ -131,30 +122,38 @@ impl DerivationPath {
     ) -> Result<Self, DeriveError> {
         let purpose = address_type.purpose();
         let coin_type = network.coin_type();
-        let change_val = i32::from(change);
-
+        let change_val = u32::from(change);
         let path_str = format!("m/{purpose}'/{coin_type}'/{account}'/{change_val}/{address_index}");
-
-        let inner = bitcoin::bip32::DerivationPath::from_str(&path_str)
-            .map_err(|e| DeriveError::Path(e.to_string()))?;
-        Ok(Self { inner })
+        Self::from_path_str(&path_str)
     }
 
-    /// Create from a custom path string.
+    /// Parse a BIP-32 path string.
     ///
     /// # Errors
     ///
-    /// Returns an error if the path string is invalid.
+    /// - Empty / master-only path → [`DeriveError::Path`]
+    /// - Malformed path → [`DeriveError::Path`]
     pub fn from_path_str(path: &str) -> Result<Self, DeriveError> {
-        let inner = bitcoin::bip32::DerivationPath::from_str(path)
+        let trimmed = path.trim();
+        if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("m") {
+            return Err(DeriveError::Path(
+                "btc: derivation path must contain at least one segment".into(),
+            ));
+        }
+        let inner = bip32::DerivationPath::from_str(trimmed)
             .map_err(|e| DeriveError::Path(e.to_string()))?;
+        if inner.is_empty() {
+            return Err(DeriveError::Path(
+                "btc: derivation path must contain at least one segment".into(),
+            ));
+        }
         Ok(Self { inner })
     }
 
-    /// Get the inner bitcoin derivation path.
+    /// Borrow the underlying `bip32` path.
     #[inline]
     #[must_use]
-    pub const fn inner(&self) -> &bitcoin::bip32::DerivationPath {
+    pub const fn inner(&self) -> &bip32::DerivationPath {
         &self.inner
     }
 }
@@ -162,13 +161,18 @@ impl DerivationPath {
 #[cfg(feature = "alloc")]
 impl fmt::Display for DerivationPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "m/{}", self.inner)
+        // Explicit `m/` prefix — do not rely on bip32's Display.
+        f.write_str("m")?;
+        for child in self.inner.iter() {
+            write!(f, "/{child}")?;
+        }
+        Ok(())
     }
 }
 
 #[cfg(feature = "alloc")]
-impl AsRef<bitcoin::bip32::DerivationPath> for DerivationPath {
-    fn as_ref(&self) -> &bitcoin::bip32::DerivationPath {
+impl AsRef<bip32::DerivationPath> for DerivationPath {
+    fn as_ref(&self) -> &bip32::DerivationPath {
         &self.inner
     }
 }
@@ -178,7 +182,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_address_type_from_str() {
+    fn address_type_from_str() {
         assert_eq!("p2pkh".parse::<AddressType>().unwrap(), AddressType::P2pkh);
         assert_eq!("legacy".parse::<AddressType>().unwrap(), AddressType::P2pkh);
         assert_eq!(
@@ -186,15 +190,7 @@ mod tests {
             AddressType::P2shP2wpkh
         );
         assert_eq!(
-            "segwit".parse::<AddressType>().unwrap(),
-            AddressType::P2shP2wpkh
-        );
-        assert_eq!(
             "p2wpkh".parse::<AddressType>().unwrap(),
-            AddressType::P2wpkh
-        );
-        assert_eq!(
-            "native-segwit".parse::<AddressType>().unwrap(),
             AddressType::P2wpkh
         );
         assert_eq!("p2tr".parse::<AddressType>().unwrap(), AddressType::P2tr);
@@ -202,19 +198,7 @@ mod tests {
     }
 
     #[test]
-    fn test_address_type_from_str_case_insensitive() {
-        assert_eq!("P2PKH".parse::<AddressType>().unwrap(), AddressType::P2pkh);
-        assert_eq!("TAPROOT".parse::<AddressType>().unwrap(), AddressType::P2tr);
-    }
-
-    #[test]
-    fn test_address_type_from_str_invalid() {
-        assert!("invalid".parse::<AddressType>().is_err());
-        assert!("".parse::<AddressType>().is_err());
-    }
-
-    #[test]
-    fn test_address_type_purpose() {
+    fn address_type_purpose() {
         assert_eq!(AddressType::P2pkh.purpose(), 44);
         assert_eq!(AddressType::P2shP2wpkh.purpose(), 49);
         assert_eq!(AddressType::P2wpkh.purpose(), 84);
@@ -222,7 +206,31 @@ mod tests {
     }
 
     #[test]
-    fn test_address_type_default() {
+    fn address_type_default() {
         assert_eq!(AddressType::default(), AddressType::P2wpkh);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn derivation_path_display_keeps_master_prefix_and_tick() {
+        let path = DerivationPath::from_path_str("m/84'/0'/0'/0/0").unwrap();
+        assert_eq!(path.to_string(), "m/84'/0'/0'/0/0");
+        assert!(path.to_string().starts_with("m/"));
+        assert!(path.to_string().contains("84'"));
+        assert!(!path.to_string().contains("84h"));
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn derivation_path_rejects_empty_forms() {
+        for bad in ["", "m", "M", "  m  ", " m"] {
+            assert!(
+                matches!(
+                    DerivationPath::from_path_str(bad),
+                    Err(DeriveError::Path(_))
+                ),
+                "expected Path error for {bad:?}"
+            );
+        }
     }
 }

--- a/crates/kobe-btc/src/wif.rs
+++ b/crates/kobe-btc/src/wif.rs
@@ -1,0 +1,88 @@
+//! Wallet Import Format (compressed secp256k1).
+//!
+//! Secret material enters and leaves only as [`Zeroizing`].
+
+use alloc::string::String;
+
+use kobe_primitives::DeriveError;
+use sha2::{Digest, Sha256};
+#[cfg(test)]
+use zeroize::Zeroize;
+use zeroize::Zeroizing;
+
+use crate::Network;
+
+/// Encode a compressed private key as WIF.
+///
+/// This is infallible for any 32-byte key. It still returns [`Result`] so the
+/// WIF path shares the same [`DeriveError`] surface as address encoding and
+/// `derive_*` methods.
+#[allow(
+    clippy::indexing_slicing,
+    reason = "fixed-size WIF payload fields are checked by construction"
+)]
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "unified DeriveError surface with create_address / derive_*"
+)]
+pub(crate) fn encode_wif(
+    private_key: &Zeroizing<[u8; 32]>,
+    network: Network,
+) -> Result<Zeroizing<String>, DeriveError> {
+    let mut payload = Zeroizing::new([0u8; 38]);
+    payload[0] = match network {
+        Network::Mainnet => 0x80,
+        Network::Testnet => 0xef,
+    };
+    payload[1..33].copy_from_slice(private_key.as_ref());
+    payload[33] = 0x01;
+
+    let first = Sha256::digest(&payload[..34]);
+    let checksum = Sha256::digest(first);
+    payload[34..].copy_from_slice(&checksum[..4]);
+
+    Ok(Zeroizing::new(
+        bs58::encode(payload.as_slice()).into_string(),
+    ))
+}
+
+/// Decode compressed WIF (tests / round-trip only).
+#[cfg(test)]
+#[allow(
+    clippy::indexing_slicing,
+    reason = "decoded WIF length is validated before fixed field access"
+)]
+pub(crate) fn decode_wif(wif: &str) -> Result<(Zeroizing<[u8; 32]>, Network), DeriveError> {
+    let mut decoded = bs58::decode(wif)
+        .into_vec()
+        .map_err(|_| DeriveError::Input("btc: invalid WIF base58".into()))?;
+
+    let result = (|| {
+        if decoded.len() != 38 {
+            return Err(DeriveError::Input(
+                "btc: invalid compressed WIF length".into(),
+            ));
+        }
+        if decoded[33] != 0x01 {
+            return Err(DeriveError::Input(
+                "btc: WIF missing compressed flag".into(),
+            ));
+        }
+        let first = Sha256::digest(&decoded[..34]);
+        let checksum = Sha256::digest(first);
+        if decoded[34..] != checksum[..4] {
+            return Err(DeriveError::Input("btc: invalid WIF checksum".into()));
+        }
+        let network = match decoded[0] {
+            0x80 => Network::Mainnet,
+            0xef => Network::Testnet,
+            _ => return Err(DeriveError::Input("btc: invalid WIF version".into())),
+        };
+        let mut key = Zeroizing::new([0u8; 32]);
+        key.copy_from_slice(&decoded[1..33]);
+        Ok((key, network))
+    })();
+
+    decoded.zeroize();
+    result
+}


### PR DESCRIPTION
Closes #35

## Description

`kobe-btc` was the only chain crate deriving keys through `bitcoin::bip32::Xpriv` instead of `kobe_primitives::Wallet::derive_secp256k1`. That kept Address/WIF inside the `bitcoin` type system, but:

- Pulled in a heavy dependency used only by this crate
- Split Bitcoin’s secp256k1 pipeline from every other chain
- Made dependency auditing / `no_std` graphs harder for downstream users who only need BTC derivation

This PR removes the `bitcoin` dependency while keeping the public API stable.

## Changes

- Key derivation via `Wallet::derive_secp256k1` (shared with other secp256k1 chains)
- Local encoding for P2PKH, P2SH-P2WPKH, P2WPKH, and P2TR (key-path-only, even-y normalized)
- Local WIF encode/decode; secrets stay in `Zeroizing`
- Errors use workspace `DeriveError` (`Path` / `Crypto` / `AddressEncoding` / `Input`)
- KATs: mainnet BIP-44/49/84/86; testnet full addresses (incl. BIP-49 official vector); WIF round-trips

## Scope

- Derivation and encoding only — no signing or spending
- P2TR is single-key, key-path-only (BIP-86 style)

## Verification

```text
cargo test -p kobe-btc --all-features
cargo test --workspace --all-features
cargo check -p kobe-btc --no-default-features --features alloc
cargo +nightly fmt --all --check
cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings