### PR TITLE
release: v3.0.0 security defaults and API hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this workspace are documented in this file. The format is
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-08-08
+
+### Security
+
+- Redacted `Debug` for secret-bearing types (`Wallet`, `DerivedAccount`, `BtcAccount`, `SvmAccount`, `NostrAccount`). `Zeroizing` does not redact; hand-written `Debug` prints `[REDACTED]` for mnemonic, seed, private keys, WIF, keypair, and `nsec`.
+- CLI defaults to hiding mnemonic and private keys. Pass global `-r` / `--reveal` to include them in human and JSON output.
+
+### Breaking (`kobe-cli`)
+
+- HD JSON/human output omits `mnemonic` and `private_key` unless `-r` / `--reveal` is set. Scripts that need secrets must pass the flag.
+
 ### Breaking (`kobe-btc`)
 
 - `Deriver::new(wallet, network)` is now infallible and returns `Self` (no longer `Result`). Call sites that used `?` should drop it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "kobe"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "kobe-aptos",
  "kobe-btc",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-aptos"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "hex",
  "kobe-primitives",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-btc"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "bech32",
  "bs58",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-cli"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "clap",
  "colored",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-cosmos"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "bech32",
  "kobe-primitives",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-evm"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "alloy-primitives",
  "kobe-primitives",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-fil"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "blake2",
  "kobe-primitives",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-nostr"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "bech32",
  "kobe-primitives",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-primitives"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "bip32",
  "bip39",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-spark"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "bech32",
  "hex",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-sui"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "blake2",
  "hex",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-svm"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "bs58",
  "kobe-primitives",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-ton"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "base64",
  "kobe-primitives",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-tron"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "bs58",
  "kobe-primitives",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-xrpl"
-version = "2.1.0"
+version = "3.0.0"
 dependencies = [
  "bs58",
  "kobe-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["fuzz"]
 resolver = "3"
 
 [workspace.package]
-version = "2.1.0"
+version = "3.0.0"
 edition = "2024"
 # Minimum supported Rust version. `edition = "2024"` was stabilized in 1.85;
 # we pin to 1.85 here and enforce it in CI. Bumping this is a breaking change.
@@ -19,20 +19,20 @@ keywords = ["crypto", "wallet", "bitcoin", "ethereum", "solana"]
 categories = ["cryptography::cryptocurrencies"]
 
 [workspace.dependencies]
-kobe-primitives = { version = "2.1", path = "crates/kobe-primitives", default-features = false }
-kobe = { version = "2.1", path = "crates/kobe", default-features = false }
-kobe-btc = { version = "2.1", path = "crates/kobe-btc", default-features = false }
-kobe-cosmos = { version = "2.1", path = "crates/kobe-cosmos", default-features = false }
-kobe-evm = { version = "2.1", path = "crates/kobe-evm", default-features = false }
-kobe-fil = { version = "2.1", path = "crates/kobe-fil", default-features = false }
-kobe-spark = { version = "2.1", path = "crates/kobe-spark", default-features = false }
-kobe-sui = { version = "2.1", path = "crates/kobe-sui", default-features = false }
-kobe-svm = { version = "2.1", path = "crates/kobe-svm", default-features = false }
-kobe-ton = { version = "2.1", path = "crates/kobe-ton", default-features = false }
-kobe-tron = { version = "2.1", path = "crates/kobe-tron", default-features = false }
-kobe-aptos = { version = "2.1", path = "crates/kobe-aptos", default-features = false }
-kobe-nostr = { version = "2.1", path = "crates/kobe-nostr", default-features = false }
-kobe-xrpl = { version = "2.1", path = "crates/kobe-xrpl", default-features = false }
+kobe-primitives = { version = "3.0", path = "crates/kobe-primitives", default-features = false }
+kobe = { version = "3.0", path = "crates/kobe", default-features = false }
+kobe-btc = { version = "3.0", path = "crates/kobe-btc", default-features = false }
+kobe-cosmos = { version = "3.0", path = "crates/kobe-cosmos", default-features = false }
+kobe-evm = { version = "3.0", path = "crates/kobe-evm", default-features = false }
+kobe-fil = { version = "3.0", path = "crates/kobe-fil", default-features = false }
+kobe-spark = { version = "3.0", path = "crates/kobe-spark", default-features = false }
+kobe-sui = { version = "3.0", path = "crates/kobe-sui", default-features = false }
+kobe-svm = { version = "3.0", path = "crates/kobe-svm", default-features = false }
+kobe-ton = { version = "3.0", path = "crates/kobe-ton", default-features = false }
+kobe-tron = { version = "3.0", path = "crates/kobe-tron", default-features = false }
+kobe-aptos = { version = "3.0", path = "crates/kobe-aptos", default-features = false }
+kobe-nostr = { version = "3.0", path = "crates/kobe-nostr", default-features = false }
+kobe-xrpl = { version = "3.0", path = "crates/kobe-xrpl", default-features = false }
 
 alloy-primitives = { version = "1.6.1", default-features = false, features = ["k256"] }
 base64 = { version = "0.23.1", default-features = false, features = ["alloc"] }

--- a/README.md
+++ b/README.md
@@ -77,9 +77,13 @@ kobe evm    import -m "abandon abandon ... about"
 
 # JSON output — stable, script- and agent-friendly
 kobe evm    new --json
+
+# Secrets (mnemonic / private keys) are hidden by default
+kobe -r evm new                          # show mnemonic + private keys
+kobe --json -r evm new                   # include them in JSON as well
 ```
 
-Every chain subcommand accepts the shared flags `-w/--words`, `-c/--count`, `-p/--passphrase`, and `--qr` through a flattened `SimpleArgs` group, so ergonomics stay consistent across the 12 networks.
+Every chain subcommand accepts the shared flags `-w/--words`, `-c/--count`, `-p/--passphrase`, and `--qr` through a flattened `SimpleArgs` group, so ergonomics stay consistent across the 12 networks. Global `-r` / `--reveal` opts into printing mnemonics and private keys (default: hidden).
 
 ### Library Usage
 
@@ -171,7 +175,7 @@ println!("Mnemonic: {}", wallet.mnemonic());
 - **Derivation styles** — Standard, Ledger Live, Ledger Legacy, Trust, Phantom, Backpack, Tonkeeper — with `FromStr` aliases and an accepted-token diagnostic on `ParseDerivationStyleError`
 - **Cross-implementation KATs** — every chain is pinned against independent references (bitcoinjs-lib, @ton/core, @noble/hashes, NIP-06 official vectors, ethanmarcuss/spark-address, BIP-84 / BIP-86 / EIP-55 / SLIP-10 test vectors) — no self-confirming dumps
 - **`no_std` + `alloc`** — every library crate compiles on `thumbv7m-none-eabi` under CI; embedded / WASM ready
-- **Security hardened** — mnemonics, seeds, private keys, WIFs, `nsec`s, and Solana keypairs wrapped in `Zeroizing<T>`; no key material is logged or persisted
+- **Security hardened** — mnemonics, seeds, private keys, WIFs, `nsec`s, and Solana keypairs wrapped in `Zeroizing<T>`; secret-bearing types redact in `Debug`; CLI hides secrets unless `--reveal`
 - **Signer integration** — [`signer`](https://github.com/qntx/signer) consumes every `DerivedAccount` / `BtcAccount` / `SvmAccount` / `NostrAccount` via `Signer::from_derived` behind its `kobe` feature flag
 - **Strict linting** — Clippy `pedantic` + `nursery` + `correctness` (deny), `rust_2018_idioms` deny, zero warnings on nightly
 
@@ -184,7 +188,9 @@ See **[`crates/README.md`](crates/README.md)** for the full crate table, depende
 This library has **not** been independently audited. Use at your own risk.
 
 - Mnemonics, seeds, and derived private keys wrapped in [`zeroize`](https://docs.rs/zeroize) — wiped from memory on drop
+- `Debug` for `Wallet`, `DerivedAccount`, and chain secret newtypes redacts key material (`[REDACTED]`); do not rely on `{:?}` for secrets
 - Chain-specific secret encodings (BTC WIF, Nostr `nsec`, Solana 64-byte keypair) are wrapped in `Zeroizing<String>` / `Zeroizing<[u8; N]>`
+- CLI omits mnemonic and private keys unless `--reveal` is passed
 - Random generation uses the OS-provided CSPRNG via [`getrandom`](https://docs.rs/getrandom); `Wallet::generate_in_with` accepts a caller-supplied `CryptoRng` on embedded / WASM targets where OS entropy is unavailable
 - `secp256k1` contexts are cached on `Deriver` to avoid the ~768 KB per-call setup cost
 - Environment-variable mutation and `std::mem::{transmute, forget}` are denied at the lint level

--- a/crates/kobe-btc/src/deriver.rs
+++ b/crates/kobe-btc/src/deriver.rs
@@ -25,12 +25,23 @@ pub struct Deriver<'a> {
 
 /// Bitcoin-specific derived account: unified [`DerivedAccount`] plus WIF,
 /// address type, and structured path.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct BtcAccount {
     inner: DerivedAccount,
     private_key_wif: Zeroizing<String>,
     address_type: AddressType,
     bip32_path: DerivationPath,
+}
+
+impl core::fmt::Debug for BtcAccount {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BtcAccount")
+            .field("inner", &self.inner)
+            .field("private_key_wif", &"[REDACTED]")
+            .field("address_type", &self.address_type)
+            .field("bip32_path", &self.bip32_path)
+            .finish()
+    }
 }
 
 impl BtcAccount {
@@ -252,6 +263,16 @@ mod tests {
 
     fn deriver(wallet: &Wallet, network: Network) -> Deriver<'_> {
         Deriver::new(wallet, network)
+    }
+
+    #[test]
+    fn debug_redacts_wif() {
+        let wallet = test_wallet();
+        let account = deriver(&wallet, Network::Mainnet).derive(0).unwrap();
+        let wif = account.private_key_wif().as_str().to_owned();
+        let dbg = alloc::format!("{account:?}");
+        assert!(dbg.contains("[REDACTED]"));
+        assert!(!dbg.contains(&wif), "Debug must not leak WIF: {dbg}");
     }
 
     #[test]

--- a/crates/kobe-cli/src/commands/aptos.rs
+++ b/crates/kobe-cli/src/commands/aptos.rs
@@ -14,8 +14,13 @@ pub(crate) struct AptosCommand {
 }
 
 impl AptosCommand {
-    pub(crate) fn execute(self, json: bool) -> Result<(), Box<dyn std::error::Error>> {
-        self.command
-            .execute("aptos", json, |w, n| Ok(Deriver::new(w).derive_many(0, n)?))
+    pub(crate) fn execute(
+        self,
+        json: bool,
+        reveal: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.command.execute("aptos", json, reveal, |w, n| {
+            Ok(Deriver::new(w).derive_many(0, n)?)
+        })
     }
 }

--- a/crates/kobe-cli/src/commands/bitcoin.rs
+++ b/crates/kobe-cli/src/commands/bitcoin.rs
@@ -82,7 +82,11 @@ const fn network(testnet: bool) -> Network {
 }
 
 impl BitcoinCommand {
-    pub(crate) fn execute(self, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    pub(crate) fn execute(
+        self,
+        json: bool,
+        reveal: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let (mnemonic, args) = match self.command {
             BitcoinSubcommand::New { args } => (None, args),
             BitcoinSubcommand::Import { mnemonic, args } => (Some(mnemonic), args),
@@ -93,7 +97,7 @@ impl BitcoinCommand {
         let addr_type = AddressType::from(args.address_type);
         let deriver = Deriver::new(&wallet, net);
         let addresses = deriver.derive_many_with(addr_type, 0, args.common.count)?;
-        let out = build_hd(&wallet, net, addr_type, &addresses);
+        let out = build_hd(&wallet, net, addr_type, &addresses, reveal);
         output::render_hd_wallet(&out, json, args.common.qr)?;
         Ok(())
     }
@@ -104,6 +108,7 @@ fn build_hd(
     net: Network,
     addr_type: AddressType,
     addresses: &[kobe::btc::BtcAccount],
+    reveal: bool,
 ) -> HdWalletOutput {
     HdWalletOutput::new(
         "bitcoin",
@@ -115,8 +120,15 @@ fn build_hd(
             .iter()
             .enumerate()
             .map(|(i, a)| {
-                AccountOutput::from_parts(i, a.path(), a.address(), a.private_key_wif().as_str())
+                AccountOutput::from_parts(
+                    i,
+                    a.path(),
+                    a.address(),
+                    a.private_key_wif().as_str(),
+                    reveal,
+                )
             })
             .collect(),
+        reveal,
     )
 }

--- a/crates/kobe-cli/src/commands/cosmos.rs
+++ b/crates/kobe-cli/src/commands/cosmos.rs
@@ -48,7 +48,11 @@ struct CosmosArgs {
 }
 
 impl CosmosCommand {
-    pub(crate) fn execute(self, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    pub(crate) fn execute(
+        self,
+        json: bool,
+        reveal: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let (mnemonic, args) = match self.command {
             CosmosSubcommand::New { args } => (None, args),
             CosmosSubcommand::Import { mnemonic, args } => (Some(mnemonic), args),
@@ -57,7 +61,7 @@ impl CosmosCommand {
 
         let deriver = Deriver::with_config(&wallet, ChainConfig::new(args.hrp, args.coin_type));
         let accounts = deriver.derive_many(0, args.common.count)?;
-        let out = HdWalletOutput::simple("cosmos", &wallet, &accounts);
+        let out = HdWalletOutput::simple("cosmos", &wallet, &accounts, reveal);
         output::render_hd_wallet(&out, json, args.common.qr)?;
         Ok(())
     }

--- a/crates/kobe-cli/src/commands/ethereum.rs
+++ b/crates/kobe-cli/src/commands/ethereum.rs
@@ -64,7 +64,11 @@ struct EthereumArgs {
 }
 
 impl EthereumCommand {
-    pub(crate) fn execute(self, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    pub(crate) fn execute(
+        self,
+        json: bool,
+        reveal: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let (mnemonic, args) = match self.command {
             EthereumSubcommand::New { args } => (None, args),
             EthereumSubcommand::Import { mnemonic, args } => (Some(mnemonic), args),
@@ -74,7 +78,7 @@ impl EthereumCommand {
         let ds = DerivationStyle::from(args.style);
         let deriver = Deriver::new(&wallet);
         let accounts = deriver.derive_many_with(ds, 0, args.common.count)?;
-        let out = build_hd(&wallet, ds, &accounts);
+        let out = build_hd(&wallet, ds, &accounts, reveal);
         output::render_hd_wallet(&out, json, args.common.qr)?;
         Ok(())
     }
@@ -84,6 +88,7 @@ fn build_hd(
     wallet: &Wallet,
     style: DerivationStyle,
     accounts: &[DerivedAccount],
+    reveal: bool,
 ) -> HdWalletOutput {
     HdWalletOutput::new(
         "ethereum",
@@ -100,8 +105,10 @@ fn build_hd(
                     a.path(),
                     a.address(),
                     &format!("0x{}", a.private_key_hex().as_str()),
+                    reveal,
                 )
             })
             .collect(),
+        reveal,
     )
 }

--- a/crates/kobe-cli/src/commands/filecoin.rs
+++ b/crates/kobe-cli/src/commands/filecoin.rs
@@ -14,8 +14,12 @@ pub(crate) struct FilecoinCommand {
 }
 
 impl FilecoinCommand {
-    pub(crate) fn execute(self, json: bool) -> Result<(), Box<dyn std::error::Error>> {
-        self.command.execute("filecoin", json, |w, n| {
+    pub(crate) fn execute(
+        self,
+        json: bool,
+        reveal: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.command.execute("filecoin", json, reveal, |w, n| {
             Ok(Deriver::new(w).derive_many(0, n)?)
         })
     }

--- a/crates/kobe-cli/src/commands/mod.rs
+++ b/crates/kobe-cli/src/commands/mod.rs
@@ -41,6 +41,10 @@ pub(crate) struct Cli {
     #[arg(long, global = true)]
     pub json: bool,
 
+    /// Include mnemonic and private keys in output (default: hidden).
+    #[arg(short = 'r', long, global = true)]
+    pub reveal: bool,
+
     #[command(subcommand)]
     pub command: Commands,
 }

--- a/crates/kobe-cli/src/commands/nostr.rs
+++ b/crates/kobe-cli/src/commands/nostr.rs
@@ -14,10 +14,15 @@ pub(crate) struct NostrCommand {
 }
 
 impl NostrCommand {
-    pub(crate) fn execute(self, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    pub(crate) fn execute(
+        self,
+        json: bool,
+        reveal: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         self.command.execute_with(
             "nostr",
             json,
+            reveal,
             |w, n| Ok(Deriver::new(w).derive_many(0, n)?),
             |a| a.nsec().as_str().to_owned(),
         )

--- a/crates/kobe-cli/src/commands/simple.rs
+++ b/crates/kobe-cli/src/commands/simple.rs
@@ -88,11 +88,17 @@ impl SimpleSubcommand {
     ///
     /// Returns an error if mnemonic expansion, wallet construction, or
     /// derivation fails.
-    pub(crate) fn execute<F>(self, chain: &'static str, json: bool, derive_fn: F) -> CliResult
+    pub(crate) fn execute<F>(
+        self,
+        chain: &'static str,
+        json: bool,
+        reveal: bool,
+        derive_fn: F,
+    ) -> CliResult
     where
         F: FnOnce(&Wallet, u32) -> CliResult<Vec<DerivedAccount>>,
     {
-        self.execute_with(chain, json, derive_fn, |a| {
+        self.execute_with(chain, json, reveal, derive_fn, |a| {
             a.private_key_hex().as_str().to_owned()
         })
     }
@@ -112,6 +118,7 @@ impl SimpleSubcommand {
         self,
         chain: &'static str,
         json: bool,
+        reveal: bool,
         derive_fn: F,
         format_private_key: G,
     ) -> CliResult
@@ -131,7 +138,7 @@ impl SimpleSubcommand {
             chain,
             network: None,
             address_type: None,
-            mnemonic: wallet.mnemonic().to_owned(),
+            mnemonic: reveal.then(|| wallet.mnemonic().to_owned()),
             passphrase_protected: wallet.has_passphrase(),
             derivation_style: None,
             accounts: accounts
@@ -143,7 +150,7 @@ impl SimpleSubcommand {
                         index: u32::try_from(i).unwrap_or(u32::MAX),
                         derivation_path: da.path().to_owned(),
                         address: da.address().to_owned(),
-                        private_key: format_private_key(a),
+                        private_key: reveal.then(|| format_private_key(a)),
                     }
                 })
                 .collect(),

--- a/crates/kobe-cli/src/commands/solana.rs
+++ b/crates/kobe-cli/src/commands/solana.rs
@@ -67,7 +67,11 @@ struct SolanaArgs {
 }
 
 impl SolanaCommand {
-    pub(crate) fn execute(self, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    pub(crate) fn execute(
+        self,
+        json: bool,
+        reveal: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let (mnemonic, args) = match self.command {
             SolanaSubcommand::New { args } => (None, args),
             SolanaSubcommand::Import { mnemonic, args } => (Some(mnemonic), args),
@@ -77,13 +81,18 @@ impl SolanaCommand {
         let ds = DerivationStyle::from(args.style);
         let deriver = Deriver::new(&wallet);
         let addresses = deriver.derive_many_with(ds, 0, args.common.count)?;
-        let out = build_hd(&wallet, ds, &addresses);
+        let out = build_hd(&wallet, ds, &addresses, reveal);
         output::render_hd_wallet(&out, json, args.common.qr)?;
         Ok(())
     }
 }
 
-fn build_hd(wallet: &Wallet, style: DerivationStyle, addresses: &[SvmAccount]) -> HdWalletOutput {
+fn build_hd(
+    wallet: &Wallet,
+    style: DerivationStyle,
+    addresses: &[SvmAccount],
+    reveal: bool,
+) -> HdWalletOutput {
     HdWalletOutput::new(
         "solana",
         wallet,
@@ -94,8 +103,15 @@ fn build_hd(wallet: &Wallet, style: DerivationStyle, addresses: &[SvmAccount]) -
             .iter()
             .enumerate()
             .map(|(i, a)| {
-                AccountOutput::from_parts(i, a.path(), a.address(), a.keypair_base58().as_str())
+                AccountOutput::from_parts(
+                    i,
+                    a.path(),
+                    a.address(),
+                    a.keypair_base58().as_str(),
+                    reveal,
+                )
             })
             .collect(),
+        reveal,
     )
 }

--- a/crates/kobe-cli/src/commands/spark.rs
+++ b/crates/kobe-cli/src/commands/spark.rs
@@ -76,7 +76,11 @@ struct SparkArgs {
 }
 
 impl SparkCommand {
-    pub(crate) fn execute(self, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    pub(crate) fn execute(
+        self,
+        json: bool,
+        reveal: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let (mnemonic, args) = match self.command {
             SparkSubcommand::New { args } => (None, args),
             SparkSubcommand::Import { mnemonic, args } => (Some(mnemonic), args),
@@ -86,24 +90,29 @@ impl SparkCommand {
         let network = Network::from(args.network);
         let deriver = Deriver::with_network(&wallet, network);
         let accounts = deriver.derive_many(0, args.common.count)?;
-        let out = build_hd(&wallet, network, &accounts);
+        let out = build_hd(&wallet, network, &accounts, reveal);
         output::render_hd_wallet(&out, json, args.common.qr)?;
         Ok(())
     }
 }
 
-fn build_hd(wallet: &Wallet, network: Network, accounts: &[DerivedAccount]) -> HdWalletOutput {
+fn build_hd(
+    wallet: &Wallet,
+    network: Network,
+    accounts: &[DerivedAccount],
+    reveal: bool,
+) -> HdWalletOutput {
     HdWalletOutput {
         chain: "spark",
         network: Some(network.name()),
         address_type: None,
-        mnemonic: wallet.mnemonic().to_owned(),
+        mnemonic: reveal.then(|| wallet.mnemonic().to_owned()),
         passphrase_protected: wallet.has_passphrase(),
         derivation_style: None,
         accounts: accounts
             .iter()
             .enumerate()
-            .map(|(i, a)| AccountOutput::from_derived(i, a))
+            .map(|(i, a)| AccountOutput::from_derived(i, a, reveal))
             .collect(),
     }
 }

--- a/crates/kobe-cli/src/commands/sui.rs
+++ b/crates/kobe-cli/src/commands/sui.rs
@@ -14,8 +14,13 @@ pub(crate) struct SuiCommand {
 }
 
 impl SuiCommand {
-    pub(crate) fn execute(self, json: bool) -> Result<(), Box<dyn std::error::Error>> {
-        self.command
-            .execute("sui", json, |w, n| Ok(Deriver::new(w).derive_many(0, n)?))
+    pub(crate) fn execute(
+        self,
+        json: bool,
+        reveal: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.command.execute("sui", json, reveal, |w, n| {
+            Ok(Deriver::new(w).derive_many(0, n)?)
+        })
     }
 }

--- a/crates/kobe-cli/src/commands/ton.rs
+++ b/crates/kobe-cli/src/commands/ton.rs
@@ -92,7 +92,11 @@ impl TonArgs {
 }
 
 impl TonCommand {
-    pub(crate) fn execute(self, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    pub(crate) fn execute(
+        self,
+        json: bool,
+        reveal: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let (mnemonic, args) = match self.command {
             TonSubcommand::New { args } => (None, args),
             TonSubcommand::Import { mnemonic, args } => (Some(mnemonic), args),
@@ -103,7 +107,7 @@ impl TonCommand {
         let style = DerivationStyle::from(args.style);
         let deriver = Deriver::with_format(&wallet, format);
         let accounts = deriver.derive_many_with(style, 0, args.common.count)?;
-        let out = build_hd(&wallet, format, style, &accounts);
+        let out = build_hd(&wallet, format, style, &accounts, reveal);
         output::render_hd_wallet(&out, json, args.common.qr)?;
         Ok(())
     }
@@ -114,6 +118,7 @@ fn build_hd(
     format: AddressFormat,
     style: DerivationStyle,
     accounts: &[DerivedAccount],
+    reveal: bool,
 ) -> HdWalletOutput {
     HdWalletOutput::new(
         "ton",
@@ -128,7 +133,8 @@ fn build_hd(
         accounts
             .iter()
             .enumerate()
-            .map(|(i, a)| AccountOutput::from_derived(i, a))
+            .map(|(i, a)| AccountOutput::from_derived(i, a, reveal))
             .collect(),
+        reveal,
     )
 }

--- a/crates/kobe-cli/src/commands/tron.rs
+++ b/crates/kobe-cli/src/commands/tron.rs
@@ -14,8 +14,13 @@ pub(crate) struct TronCommand {
 }
 
 impl TronCommand {
-    pub(crate) fn execute(self, json: bool) -> Result<(), Box<dyn std::error::Error>> {
-        self.command
-            .execute("tron", json, |w, n| Ok(Deriver::new(w).derive_many(0, n)?))
+    pub(crate) fn execute(
+        self,
+        json: bool,
+        reveal: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.command.execute("tron", json, reveal, |w, n| {
+            Ok(Deriver::new(w).derive_many(0, n)?)
+        })
     }
 }

--- a/crates/kobe-cli/src/commands/xrpl.rs
+++ b/crates/kobe-cli/src/commands/xrpl.rs
@@ -14,8 +14,13 @@ pub(crate) struct XrplCommand {
 }
 
 impl XrplCommand {
-    pub(crate) fn execute(self, json: bool) -> Result<(), Box<dyn std::error::Error>> {
-        self.command
-            .execute("xrpl", json, |w, n| Ok(Deriver::new(w).derive_many(0, n)?))
+    pub(crate) fn execute(
+        self,
+        json: bool,
+        reveal: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.command.execute("xrpl", json, reveal, |w, n| {
+            Ok(Deriver::new(w).derive_many(0, n)?)
+        })
     }
 }

--- a/crates/kobe-cli/src/main.rs
+++ b/crates/kobe-cli/src/main.rs
@@ -34,19 +34,20 @@ fn main() -> std::process::ExitCode {
 /// Dispatch CLI commands and propagate errors.
 fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     let json = cli.json;
+    let reveal = cli.reveal;
     match cli.command {
-        Commands::Aptos(cmd) => cmd.execute(json)?,
-        Commands::Bitcoin(cmd) => cmd.execute(json)?,
-        Commands::Ethereum(cmd) => cmd.execute(json)?,
-        Commands::Solana(cmd) => cmd.execute(json)?,
-        Commands::Cosmos(cmd) => cmd.execute(json)?,
-        Commands::Tron(cmd) => cmd.execute(json)?,
-        Commands::Spark(cmd) => cmd.execute(json)?,
-        Commands::Filecoin(cmd) => cmd.execute(json)?,
-        Commands::Ton(cmd) => cmd.execute(json)?,
-        Commands::Sui(cmd) => cmd.execute(json)?,
-        Commands::Xrpl(cmd) => cmd.execute(json)?,
-        Commands::Nostr(cmd) => cmd.execute(json)?,
+        Commands::Aptos(cmd) => cmd.execute(json, reveal)?,
+        Commands::Bitcoin(cmd) => cmd.execute(json, reveal)?,
+        Commands::Ethereum(cmd) => cmd.execute(json, reveal)?,
+        Commands::Solana(cmd) => cmd.execute(json, reveal)?,
+        Commands::Cosmos(cmd) => cmd.execute(json, reveal)?,
+        Commands::Tron(cmd) => cmd.execute(json, reveal)?,
+        Commands::Spark(cmd) => cmd.execute(json, reveal)?,
+        Commands::Filecoin(cmd) => cmd.execute(json, reveal)?,
+        Commands::Ton(cmd) => cmd.execute(json, reveal)?,
+        Commands::Sui(cmd) => cmd.execute(json, reveal)?,
+        Commands::Xrpl(cmd) => cmd.execute(json, reveal)?,
+        Commands::Nostr(cmd) => cmd.execute(json, reveal)?,
         Commands::Mnemonic(cmd) => cmd.execute(json)?,
     }
     Ok(())

--- a/crates/kobe-cli/src/output.rs
+++ b/crates/kobe-cli/src/output.rs
@@ -3,6 +3,9 @@
 //! These types serve as the single source of truth for both JSON and
 //! human-readable output. Chain-specific code builds these structs,
 //! then calls the shared render functions.
+//!
+//! **Security default:** mnemonic and private keys are omitted unless
+//! the global `--reveal` flag was set when building the output.
 
 use colored::Colorize;
 use kobe::{DerivedAccount, Wallet};
@@ -20,8 +23,9 @@ pub struct HdWalletOutput {
     /// Address type description (Bitcoin only).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub address_type: Option<&'static str>,
-    /// BIP-39 mnemonic phrase.
-    pub mnemonic: String,
+    /// BIP-39 mnemonic phrase. Present only when `--reveal` was used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mnemonic: Option<String>,
     /// Whether a BIP-39 passphrase was used.
     pub passphrase_protected: bool,
     /// Derivation path style name (EVM/SVM only).
@@ -41,8 +45,9 @@ pub struct AccountOutput {
     pub derivation_path: String,
     /// Blockchain address.
     pub address: String,
-    /// Private key (format depends on chain: WIF for BTC, hex for EVM, base58 for SVM).
-    pub private_key: String,
+    /// Private key (format depends on chain). Present only when `--reveal` was used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub private_key: Option<String>,
 }
 
 /// Output for mnemonic camouflage operations.
@@ -61,6 +66,8 @@ pub struct CamouflageOutput {
 
 impl HdWalletOutput {
     /// Build HD output with optional network / address-type / style metadata.
+    ///
+    /// When `reveal` is false, `mnemonic` is omitted from the struct.
     #[must_use]
     pub fn new(
         chain: &'static str,
@@ -69,12 +76,13 @@ impl HdWalletOutput {
         address_type: Option<&'static str>,
         derivation_style: Option<&'static str>,
         accounts: Vec<AccountOutput>,
+        reveal: bool,
     ) -> Self {
         Self {
             chain,
             network,
             address_type,
-            mnemonic: wallet.mnemonic().to_owned(),
+            mnemonic: reveal.then(|| wallet.mnemonic().to_owned()),
             passphrase_protected: wallet.has_passphrase(),
             derivation_style,
             accounts,
@@ -83,7 +91,12 @@ impl HdWalletOutput {
 
     /// Build output for a simple chain (no network, no address type, no derivation style).
     #[must_use]
-    pub fn simple(chain: &'static str, wallet: &Wallet, accounts: &[DerivedAccount]) -> Self {
+    pub fn simple(
+        chain: &'static str,
+        wallet: &Wallet,
+        accounts: &[DerivedAccount],
+        reveal: bool,
+    ) -> Self {
         Self::new(
             chain,
             wallet,
@@ -93,8 +106,9 @@ impl HdWalletOutput {
             accounts
                 .iter()
                 .enumerate()
-                .map(|(i, a)| AccountOutput::from_derived(i, a))
+                .map(|(i, a)| AccountOutput::from_derived(i, a, reveal))
                 .collect(),
+            reveal,
         )
     }
 }
@@ -102,28 +116,32 @@ impl HdWalletOutput {
 impl AccountOutput {
     /// Build from a [`DerivedAccount`] with a sequential index.
     #[must_use]
-    pub fn from_derived(index: usize, account: &DerivedAccount) -> Self {
+    pub fn from_derived(index: usize, account: &DerivedAccount, reveal: bool) -> Self {
         Self::from_parts(
             index,
             account.path(),
             account.address(),
             account.private_key_hex().as_str(),
+            reveal,
         )
     }
 
     /// Build with an explicit private-key string (WIF, base58 keypair, `0x…` hex, …).
+    ///
+    /// The key is stored only when `reveal` is true.
     #[must_use]
     pub fn from_parts(
         index: usize,
         derivation_path: &str,
         address: &str,
         private_key: &str,
+        reveal: bool,
     ) -> Self {
         Self {
             index: u32::try_from(index).unwrap_or(u32::MAX),
             derivation_path: derivation_path.to_owned(),
             address: address.to_owned(),
-            private_key: private_key.to_owned(),
+            private_key: reveal.then(|| private_key.to_owned()),
         }
     }
 }
@@ -158,7 +176,15 @@ pub fn render_hd_wallet(
     if let Some(addr_type) = out.address_type {
         println!("      {} {}", "Address Type".cyan().bold(), addr_type);
     }
-    println!("      {}     {}", "Mnemonic".cyan().bold(), out.mnemonic);
+    if let Some(ref mnemonic) = out.mnemonic {
+        println!("      {}     {}", "Mnemonic".cyan().bold(), mnemonic);
+    } else {
+        println!(
+            "      {}     {}",
+            "Mnemonic".cyan().bold(),
+            "(hidden; pass -r / --reveal)".dimmed()
+        );
+    }
     if out.passphrase_protected {
         println!("      {}   {}", "Passphrase".cyan().bold(), "(set)".dimmed());
     }
@@ -174,7 +200,15 @@ pub fn render_hd_wallet(
         }
         println!("      {}         {}", "Path".cyan().bold(), acct.derivation_path);
         println!("      {}      {}", "Address".cyan().bold(), acct.address.green());
-        println!("      {}  {}", "Private Key".cyan().bold(), acct.private_key);
+        if let Some(ref pk) = acct.private_key {
+            println!("      {}  {}", "Private Key".cyan().bold(), pk);
+        } else {
+            println!(
+                "      {}  {}",
+                "Private Key".cyan().bold(),
+                "(hidden; pass -r / --reveal)".dimmed()
+            );
+        }
         if show_qr {
             crate::qr::render_to_terminal(&acct.address);
         }

--- a/crates/kobe-nostr/src/deriver.rs
+++ b/crates/kobe-nostr/src/deriver.rs
@@ -25,10 +25,19 @@ pub const NPUB_HRP: &str = "npub";
 ///
 /// Implements `Deref<Target = DerivedAccount>`, so all shared accessors
 /// (`address()`, `public_key_bytes()`, etc.) are available directly.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct NostrAccount {
     inner: DerivedAccount,
     nsec: Zeroizing<String>,
+}
+
+impl core::fmt::Debug for NostrAccount {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NostrAccount")
+            .field("inner", &self.inner)
+            .field("nsec", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl NostrAccount {
@@ -204,6 +213,18 @@ mod tests {
 
     fn wallet(mnemonic: &str) -> Wallet {
         Wallet::from_mnemonic(mnemonic, None).unwrap()
+    }
+
+    #[test]
+    fn debug_redacts_nsec() {
+        let a = Deriver::new(&wallet(TV1_MNEMONIC)).derive(0).unwrap();
+        let dbg = format!("{a:?}");
+        assert!(dbg.contains("[REDACTED]"));
+        assert!(!dbg.contains(TV1_NSEC), "Debug must not leak nsec: {dbg}");
+        assert!(
+            !dbg.contains(TV1_PRIV_HEX),
+            "Debug must not leak private key hex: {dbg}"
+        );
     }
 
     /// Official NIP-06 test vector 1 — full 4-way lock

--- a/crates/kobe-primitives/src/derive.rs
+++ b/crates/kobe-primitives/src/derive.rs
@@ -194,13 +194,25 @@ impl core::fmt::Display for PublicKeyKind {
 /// implement [`AsRef<DerivedAccount>`] + `Deref<Target = DerivedAccount>`
 /// on it. This guarantees generic code can always obtain the unified view
 /// without erasing chain-specific information.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 #[non_exhaustive]
 pub struct DerivedAccount {
     path: String,
     private_key: Zeroizing<[u8; 32]>,
     public_key: DerivedPublicKey,
     address: String,
+}
+
+impl core::fmt::Debug for DerivedAccount {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Never print private key material — Zeroizing's Debug is not redacting.
+        f.debug_struct("DerivedAccount")
+            .field("path", &self.path)
+            .field("private_key", &"[REDACTED]")
+            .field("public_key", &self.public_key)
+            .field("address", &self.address)
+            .finish()
+    }
 }
 
 impl DerivedAccount {
@@ -479,5 +491,21 @@ mod tests {
         let acct = sample_account();
         let borrowed: &DerivedAccount = acct.as_ref();
         assert!(core::ptr::eq(borrowed, &raw const acct));
+    }
+
+    #[test]
+    fn debug_redacts_private_key() {
+        let acct = sample_account();
+        let dbg = alloc::format!("{acct:?}");
+        assert!(
+            dbg.contains("[REDACTED]"),
+            "expected redaction markers: {dbg}"
+        );
+        assert!(
+            !dbg.contains("1ab42cc412b618bdea3a599e3c9bae199ebf030895b039e9db1e30dafb12b727"),
+            "Debug must not leak private key hex: {dbg}"
+        );
+        // Public material remains visible for diagnostics.
+        assert!(dbg.contains("0x9858EfFD232B4033E47d90003D41EC34EcaEda94"));
     }
 }

--- a/crates/kobe-primitives/src/wallet.rs
+++ b/crates/kobe-primitives/src/wallet.rs
@@ -20,7 +20,6 @@ use crate::DeriveError;
 /// The wallet supports an optional BIP39 passphrase (sometimes called "25th word").
 /// This provides an extra layer of security - the same mnemonic with different
 /// passphrases will produce completely different wallets.
-#[derive(Debug)]
 pub struct Wallet {
     /// BIP39 mnemonic phrase.
     mnemonic: Zeroizing<String>,
@@ -39,6 +38,19 @@ pub struct Wallet {
     has_passphrase: bool,
     /// Language of the mnemonic.
     language: Language,
+}
+
+impl core::fmt::Debug for Wallet {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Never print mnemonic or seed — Zeroizing's Debug is not redacting.
+        f.debug_struct("Wallet")
+            .field("mnemonic", &"[REDACTED]")
+            .field("seed", &"[REDACTED]")
+            .field("has_passphrase", &self.has_passphrase)
+            .field("language", &self.language)
+            .field("word_count", &self.word_count())
+            .finish()
+    }
 }
 
 impl Wallet {
@@ -385,6 +397,25 @@ mod tests {
             hex::encode(wallet.seed()),
             "5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc1\
              9a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4"
+        );
+    }
+
+    #[test]
+    fn debug_redacts_mnemonic_and_seed() {
+        let wallet = Wallet::from_mnemonic(TEST_MNEMONIC, None).unwrap();
+        let dbg = alloc::format!("{wallet:?}");
+        assert!(
+            dbg.contains("[REDACTED]"),
+            "expected redaction markers: {dbg}"
+        );
+        assert!(
+            !dbg.contains("abandon"),
+            "Debug must not leak mnemonic words: {dbg}"
+        );
+        // BIP-39 seed hex prefix for abandon…about
+        assert!(
+            !dbg.contains("5eb00bbddcf06908"),
+            "Debug must not leak seed bytes: {dbg}"
         );
     }
 

--- a/crates/kobe-svm/src/deriver.rs
+++ b/crates/kobe-svm/src/deriver.rs
@@ -29,10 +29,19 @@ use crate::derivation_style::DerivationStyle;
 ///
 /// Implements `Deref<Target = DerivedAccount>`, so all shared accessors
 /// (`address()`, `public_key_bytes()`, etc.) are available directly.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SvmAccount {
     inner: DerivedAccount,
     keypair_base58: Zeroizing<String>,
+}
+
+impl core::fmt::Debug for SvmAccount {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SvmAccount")
+            .field("inner", &self.inner)
+            .field("keypair_base58", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl SvmAccount {
@@ -221,6 +230,15 @@ mod tests {
     /// (`bip39 → ed25519-hd-key SLIP-10 → tweetnacl key pair → base58`)
     /// per the Solana wallet adapter defaults documented at
     /// <https://docs.phantom.app/>.
+    #[test]
+    fn debug_redacts_keypair_base58() {
+        let acct = Deriver::new(&test_wallet()).derive(0).unwrap();
+        let kp = acct.keypair_base58().as_str().to_owned();
+        let dbg = format!("{acct:?}");
+        assert!(dbg.contains("[REDACTED]"));
+        assert!(!dbg.contains(&kp), "Debug must not leak keypair: {dbg}");
+    }
+
     #[test]
     fn kat_solana_phantom_abandon_index0() {
         let acct = Deriver::new(&test_wallet()).derive(0).unwrap();

--- a/crates/kobe/src/lib.rs
+++ b/crates/kobe/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! kobe = { version = "2.0", features = ["evm", "btc", "svm"] }
+//! kobe = { version = "3.0", features = ["evm", "btc", "svm"] }
 //! ```
 //!
 //! ```no_run

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -43,6 +43,16 @@ All account types implement `AsRef<DerivedAccount>` (and usually `Deref`).
 | `Wallet::derive_secp256k1` / `derive_ed25519` | Preferred inside chain crates. |
 | `Wallet::seed` | **Feature `raw-seed` only** (off by default). |
 
+## Debug / secrets
+
+| Type | `Debug` contract |
+| --- | --- |
+| `Wallet` | Redacts mnemonic and seed (`[REDACTED]`). |
+| `DerivedAccount` | Redacts private key; path, pubkey, address visible. |
+| `BtcAccount` / `SvmAccount` / `NostrAccount` | Redacts WIF / keypair / `nsec`. |
+
+`Zeroizing<T>` itself does **not** redact; do not `#[derive(Debug)]` on types that hold secrets.
+
 ## Errors
 
 All chains surface `kobe_primitives::DeriveError` only (`Path`, `Crypto`,

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,9 @@
+# Release checklist
+
+1. CI green on `main` (`lint`, `test`, `deny`, `no_std`).
+2. Local: `just all` (or equivalent fmt/clippy/deny/no_std) and `just test`.
+3. `CHANGELOG.md` has a dated section for the version being tagged; no open **Breaking** bullets under `[Unreleased]` that belong in the release.
+4. Workspace `version` and path deps match the tag (`3.0.0` → path `"3.0"`).
+5. Tag and push: `git tag v3.0.0 && git push origin v3.0.0` (or push with `--tags`).
+6. Confirm GitHub Actions `release.yml` and `publish.yml` succeed.
+7. crates.io publish order is handled by the workflow: primitives → chain crates → `kobe` → `kobe-cli`.


### PR DESCRIPTION
## Summary

- **Security:** Hand-written `Debug` for `Wallet`, `DerivedAccount`, `BtcAccount`, `SvmAccount`, and `NostrAccount` redacts mnemonic/seed/private keys/WIF/keypair/`nsec` (`Zeroizing` does not redact by itself).
- **CLI:** Secrets hidden by default; global `-r` / `--reveal` opts in for human and JSON output.
- **Version:** Workspace bumped to **3.0.0** (honest SemVer for existing + new breaking surface vs 2.0.1).
- **Docs:** CHANGELOG `[3.0.0]`, README, `docs/API_CONTRACT.md` (Debug/secrets), `docs/RELEASE.md`.

Also ships previously unreleased 2.x breakings documented in the changelog (`raw-seed` gate, infallible `kobe-btc::Deriver::new`, local BTC paths without public `bip32` types, etc.).

## Test plan

- [x] `cargo test --workspace --all-features`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo deny check`
- [x] CLI: `kobe evm new` hides secrets; `kobe -r evm new` / `kobe -r --json evm new` shows them
- [x] Redaction unit tests for Wallet / DerivedAccount / Btc / Svm / Nostr

## Post-merge

Tag `v3.0.0` and push tags to run release + crates.io publish workflows (see `docs/RELEASE.md`).