### PR TITLE
feat(cli): kobe upgrade self-update via sh.qntx.fun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this workspace are documented in this file. The format is
 
 ## [Unreleased]
 
+### Added
+
+- CLI `kobe upgrade` (`update` alias): self-upgrade via the official
+  `sh.qntx.fun` installer. Supports `--check`, `--force`, and `--json`.
+  Cargo-installed binaries are not overwritten (prints `cargo install` hint).
+
 ## [3.0.0] - 2026-08-08
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ kobe evm    new --json
 # Secrets (mnemonic / private keys) are hidden by default
 kobe -r evm new                          # show mnemonic + private keys
 kobe --json -r evm new                   # include them in JSON as well
+
+# Self-upgrade (sh.qntx.fun install path; same as re-running the install script)
+kobe upgrade                             # install latest if newer (`update` is an alias)
+kobe upgrade --check                     # report only
+kobe upgrade --force                     # reinstall even when up to date
 ```
 
 Every chain subcommand accepts the shared flags `-w/--words`, `-c/--count`, `-p/--passphrase`, and `--qr` through a flattened `SimpleArgs` group, so ergonomics stay consistent across the 12 networks. Global `-r` / `--reveal` opts into printing mnemonics and private keys (default: hidden).

--- a/crates/README.md
+++ b/crates/README.md
@@ -16,7 +16,7 @@
 | **[`kobe-spark`](kobe-spark/)** | [![crates.io][kobe-spark-crate]][kobe-spark-crate-url] [![docs.rs][kobe-spark-doc]][kobe-spark-doc-url] | Spark (Bitcoin L2) — identity keys + Bech32m `spark1…` addresses |
 | **[`kobe-xrpl`](kobe-xrpl/)** | [![crates.io][kobe-xrpl-crate]][kobe-xrpl-crate-url] [![docs.rs][kobe-xrpl-doc]][kobe-xrpl-doc-url] | XRP Ledger — classic `r`-addresses, secp256k1 |
 | **[`kobe-nostr`](kobe-nostr/)** | [![crates.io][kobe-nostr-crate]][kobe-nostr-crate-url] [![docs.rs][kobe-nostr-doc]][kobe-nostr-doc-url] | Nostr — NIP-06 key derivation, NIP-19 bech32 `nsec`/`npub` |
-| **[`kobe-cli`](kobe-cli/)** | [![crates.io][kobe-cli-crate]][kobe-cli-crate-url] | CLI — generate, import, derive across all chains |
+| **[`kobe-cli`](kobe-cli/)** | [![crates.io][kobe-cli-crate]][kobe-cli-crate-url] | CLI — generate, import, derive; `upgrade` via sh.qntx.fun |
 
 ## Dependency Graph
 

--- a/crates/kobe-cli/src/commands/mod.rs
+++ b/crates/kobe-cli/src/commands/mod.rs
@@ -13,6 +13,7 @@ mod spark;
 mod sui;
 mod ton;
 mod tron;
+mod update;
 mod xrpl;
 
 pub(crate) use aptos::AptosCommand;
@@ -29,6 +30,7 @@ pub(crate) use spark::SparkCommand;
 pub(crate) use sui::SuiCommand;
 pub(crate) use ton::TonCommand;
 pub(crate) use tron::TronCommand;
+pub(crate) use update::UpdateCommand;
 pub(crate) use xrpl::XrplCommand;
 
 /// Kobe - A multi-chain cryptocurrency wallet CLI tool.
@@ -103,6 +105,13 @@ pub(crate) enum Commands {
     /// Mnemonic utilities (camouflage encrypt/decrypt).
     #[command(name = "mnemonic", alias = "mn")]
     Mnemonic(MnemonicCommand),
+
+    /// Upgrade this CLI via the official sh.qntx.fun installer.
+    ///
+    /// Primary name is `upgrade` (install a newer release of the binary).
+    /// `update` is kept as an alias for familiarity.
+    #[command(name = "upgrade", alias = "update")]
+    Upgrade(UpdateCommand),
 }
 
 #[cfg(test)]

--- a/crates/kobe-cli/src/commands/update.rs
+++ b/crates/kobe-cli/src/commands/update.rs
@@ -1,0 +1,315 @@
+//! Self-upgrade via the official sh.qntx.fun installer (`kobe upgrade`).
+//!
+//! **Naming:** the primary subcommand is `upgrade` (replace this binary with a
+//! newer release). `update` is an alias. This matches tools like Deno/Bun
+//! (`upgrade`) rather than apt's split of `update` (refresh indexes) vs
+//! `upgrade` (install packages).
+//!
+//! Reuses the same install path as:
+//! - `curl -fsSL https://sh.qntx.fun/kobe | sh` (Unix)
+//! - `irm https://sh.qntx.fun/kobe/ps | iex` (Windows)
+//!
+//! Cargo-installed binaries are not overwritten; users are directed to
+//! `cargo install kobe-cli --force` instead.
+
+use std::process::Command;
+
+use clap::Args;
+use serde::Serialize;
+
+use crate::output;
+
+/// GitHub repository for releases / installer substitution.
+const REPO: &str = "qntx/kobe";
+/// Official install endpoint (Unix shell).
+#[cfg(not(windows))]
+const INSTALL_SH_URL: &str = "https://sh.qntx.fun/kobe";
+/// Official install endpoint (PowerShell).
+#[cfg(windows)]
+const INSTALL_PS_URL: &str = "https://sh.qntx.fun/kobe/ps";
+
+/// Upgrade the `kobe` CLI binary in place (`kobe upgrade` / `kobe update`).
+#[derive(Args, Debug)]
+pub(crate) struct UpdateCommand {
+    /// Only report whether a newer release is available; do not install.
+    #[arg(long)]
+    check: bool,
+
+    /// Re-run the installer even when already on the latest version.
+    #[arg(long)]
+    force: bool,
+}
+
+/// Structured result for `--json`.
+#[derive(Debug, Serialize)]
+#[non_exhaustive]
+struct UpdateOutput {
+    current: String,
+    latest: String,
+    update_available: bool,
+    action: &'static str,
+    message: String,
+}
+
+impl UpdateCommand {
+    pub(crate) fn execute(self, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+        let current = env!("CARGO_PKG_VERSION").to_owned();
+        let latest = fetch_latest_version()?;
+        let update_available = is_newer(&latest, &current);
+
+        if self.check {
+            let action = if update_available {
+                "update_available"
+            } else {
+                "up_to_date"
+            };
+            let message = if update_available {
+                format!("kobe {latest} is available (current {current})")
+            } else {
+                format!("kobe {current} is up to date")
+            };
+            return emit(
+                json,
+                &UpdateOutput {
+                    current,
+                    latest,
+                    update_available,
+                    action,
+                    message,
+                },
+            );
+        }
+
+        if !update_available && !self.force {
+            let message = format!("kobe {current} is already the latest version");
+            return emit(
+                json,
+                &UpdateOutput {
+                    current,
+                    latest,
+                    update_available: false,
+                    action: "noop",
+                    message,
+                },
+            );
+        }
+
+        if is_cargo_install()? {
+            let message = format!(
+                "this binary looks cargo-installed; run: cargo install kobe-cli --force --version {latest}"
+            );
+            if json {
+                return emit(
+                    json,
+                    &UpdateOutput {
+                        current,
+                        latest,
+                        update_available,
+                        action: "cargo_redirect",
+                        message,
+                    },
+                );
+            }
+            eprintln!("{message}");
+            return Ok(());
+        }
+
+        if !json {
+            #[cfg(not(windows))]
+            let endpoint = INSTALL_SH_URL;
+            #[cfg(windows)]
+            let endpoint = INSTALL_PS_URL;
+            if update_available {
+                println!("Updating kobe {current} → {latest} via {endpoint} …");
+            } else {
+                println!("Reinstalling kobe {current} via installer (--force) …");
+            }
+        }
+
+        run_official_installer()?;
+
+        emit(
+            json,
+            &UpdateOutput {
+                current,
+                latest: latest.clone(),
+                update_available,
+                action: "updated",
+                message: format!(
+                    "installer finished; run `kobe --version` to confirm (target {latest})"
+                ),
+            },
+        )
+    }
+}
+
+fn emit(json: bool, out: &UpdateOutput) -> Result<(), Box<dyn std::error::Error>> {
+    if json {
+        output::print_json(out)?;
+    } else {
+        println!("{}", out.message);
+    }
+    Ok(())
+}
+
+/// Fetch latest release tag from GitHub (no `v` prefix).
+fn fetch_latest_version() -> Result<String, Box<dyn std::error::Error>> {
+    let url = format!("https://api.github.com/repos/{REPO}/releases/latest");
+    let body = http_get(&url)?;
+    parse_latest_tag(&body).ok_or_else(|| {
+        "failed to parse latest version from GitHub (network error or rate limited)".into()
+    })
+}
+
+/// Pull `"tag_name":"vX.Y.Z"` without a full JSON dependency beyond string scan.
+fn parse_latest_tag(body: &str) -> Option<String> {
+    const KEY: &str = "\"tag_name\"";
+    let i = body.find(KEY)?;
+    let after = body.get(i + KEY.len()..)?;
+    let colon = after.find(':')?;
+    let rest = after.get(colon + 1..)?;
+    let start_q = rest.find('"')?;
+    let rest = rest.get(start_q + 1..)?;
+    let end_q = rest.find('"')?;
+    let tag = rest.get(..end_q)?;
+    Some(tag.trim_start_matches('v').to_owned())
+}
+
+/// True when `latest` is strictly greater than `current` (numeric semver triples).
+fn is_newer(latest: &str, current: &str) -> bool {
+    match (parse_semver(latest), parse_semver(current)) {
+        (Some(l), Some(c)) => l > c,
+        _ => latest != current,
+    }
+}
+
+fn parse_semver(s: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = s.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    // Ignore pre-release suffix on patch if present (e.g. 3.0.0-rc.1 → fail → string cmp).
+    if parts.next().is_some() {
+        // more than 3 components — only accept pure X.Y.Z
+        return None;
+    }
+    Some((major, minor, patch))
+}
+
+fn http_get(url: &str) -> Result<String, Box<dyn std::error::Error>> {
+    // Prefer curl/wget so we match the installer toolchain and avoid HTTP crates.
+    if command_exists("curl") {
+        let out = Command::new("curl")
+            .args([
+                "-fsSL",
+                "-A",
+                "kobe-update",
+                "-H",
+                "Accept: application/vnd.github+json",
+                url,
+            ])
+            .output()?;
+        if out.status.success() {
+            return Ok(String::from_utf8(out.stdout)?);
+        }
+        return Err(format!(
+            "curl failed ({}): {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        )
+        .into());
+    }
+    if command_exists("wget") {
+        let out = Command::new("wget")
+            .args(["-q", "--user-agent=kobe-update", "-O-", url])
+            .output()?;
+        if out.status.success() {
+            return Ok(String::from_utf8(out.stdout)?);
+        }
+        return Err(format!(
+            "wget failed ({}): {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        )
+        .into());
+    }
+    Err("curl or wget is required for `kobe upgrade`".into())
+}
+
+fn command_exists(name: &str) -> bool {
+    Command::new(name)
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+fn is_cargo_install() -> Result<bool, Box<dyn std::error::Error>> {
+    let exe = std::env::current_exe()?;
+    let s = exe.to_string_lossy();
+    Ok(s.contains(".cargo/bin") || s.contains(".cargo\\bin"))
+}
+
+fn run_official_installer() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(windows)]
+    {
+        let status = Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                &format!("irm {INSTALL_PS_URL} | iex"),
+            ])
+            .status()?;
+        if !status.success() {
+            return Err(format!("installer exited with {status}").into());
+        }
+        return Ok(());
+    }
+
+    #[cfg(not(windows))]
+    {
+        // Pipe curl into sh — same entrypoint as README install instructions.
+        if !command_exists("curl") {
+            return Err("curl is required to run the official installer".into());
+        }
+        if !command_exists("sh") {
+            return Err("sh is required to run the official installer".into());
+        }
+        let status = Command::new("sh")
+            .args(["-c", &format!("curl -fsSL {INSTALL_SH_URL} | sh")])
+            .status()?;
+        if !status.success() {
+            return Err(format!("installer exited with {status}").into());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_tag_from_github_payload() {
+        let body = r#"{"url":"...","tag_name":"v3.0.0","name":"v3.0.0"}"#;
+        assert_eq!(parse_latest_tag(body).as_deref(), Some("3.0.0"));
+    }
+
+    #[test]
+    fn parse_tag_without_v_prefix() {
+        let body = r#"{"tag_name": "3.1.0"}"#;
+        assert_eq!(parse_latest_tag(body).as_deref(), Some("3.1.0"));
+    }
+
+    #[test]
+    fn semver_newer() {
+        assert!(is_newer("3.0.1", "3.0.0"));
+        assert!(is_newer("3.1.0", "3.0.9"));
+        assert!(is_newer("4.0.0", "3.9.9"));
+        assert!(!is_newer("3.0.0", "3.0.0"));
+        assert!(!is_newer("2.9.9", "3.0.0"));
+    }
+}

--- a/crates/kobe-cli/src/main.rs
+++ b/crates/kobe-cli/src/main.rs
@@ -49,6 +49,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Commands::Xrpl(cmd) => cmd.execute(json, reveal)?,
         Commands::Nostr(cmd) => cmd.execute(json, reveal)?,
         Commands::Mnemonic(cmd) => cmd.execute(json)?,
+        Commands::Upgrade(cmd) => cmd.execute(json)?,
     }
     Ok(())
 }

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,3 +7,15 @@
 5. Tag and push: `git tag v3.0.0 && git push origin v3.0.0` (or push with `--tags`).
 6. Confirm GitHub Actions `release.yml` and `publish.yml` succeed.
 7. crates.io publish order is handled by the workflow: primitives → chain crates → `kobe` → `kobe-cli`.
+
+## Post-install self-upgrade
+
+Users who installed via `https://sh.qntx.fun/kobe` can run:
+
+```bash
+kobe upgrade          # or: kobe update
+kobe upgrade --check
+```
+
+That re-invokes the same installer endpoint. Cargo installs should use
+`cargo install kobe-cli --force` instead (the command detects `.cargo/bin`).

--- a/skills/kobe/SKILL.md
+++ b/skills/kobe/SKILL.md
@@ -37,13 +37,26 @@ These scripts download the latest pre-built binary from GitHub Releases and add 
 kobe --version
 ```
 
+### Self-upgrade (sh.qntx.fun installs)
+
+```sh
+kobe upgrade              # install latest if newer (`update` is an alias)
+kobe upgrade --check      # report only
+kobe upgrade --force      # reinstall even when up to date
+```
+
+Re-runs the same installer as above. Cargo-installed binaries are **not**
+overwritten; the command prints a `cargo install kobe-cli --force` hint instead.
+
 ## CLI Structure
 
 ```text
-kobe [--json] <chain> <subcommand> [options]
+kobe [--json] [-r|--reveal] <command> [options]
 ```
 
-The `--json` flag is **global** and must appear **before** the chain subcommand. When set, all output (including errors) is a single JSON object on stdout with no ANSI colors.
+The `--json` and `-r` / `--reveal` flags are **global**. When `--json` is set, all output (including errors) is a single JSON object on stdout with no ANSI colors.
+
+**Secrets default to hidden:** mnemonic and private keys are omitted unless `-r` / `--reveal` is passed.
 
 ### Chain subcommands and aliases
 
@@ -62,6 +75,7 @@ The `--json` flag is **global** and must appear **before** the chain subcommand.
 | XRP Ledger | `xrpl`     | `xrp`, `ripple`   |
 | Nostr      | `nostr`    | —                 |
 | Mnemonic   | `mnemonic` | `mn`              |
+| Upgrade    | `upgrade`  | `update`          |
 
 ### Subcommands per chain
 
@@ -83,12 +97,15 @@ The `mnemonic` command supports:
 
 | Flag           | Short | Scope           | Description                                              |
 | -------------- | ----- | --------------- | -------------------------------------------------------- |
-| `--json`       |       | Global          | JSON output mode (must come before chain subcommand)     |
+| `--json`       |       | Global          | JSON output mode                                         |
+| `--reveal`     | `-r`  | Global          | Include mnemonic and private keys (default: hidden)      |
 | `--words`      | `-w`  | `new`           | Mnemonic word count: 12, 15, 18, 21, or 24 (default: 12) |
 | `--passphrase` | `-p`  | `new`, `import` | Optional BIP-39 passphrase for seed derivation           |
 | `--count`      | `-c`  | `new`, `import` | Number of addresses to derive (default: 1)               |
 | `--qr`         |       | All             | Display QR code in terminal for each address             |
 | `--mnemonic`   | `-m`  | `import`        | BIP-39 mnemonic phrase (supports prefix abbreviation)    |
+| `--check`      |       | `upgrade`       | Only report whether a newer release exists               |
+| `--force`      |       | `upgrade`       | Re-run installer even when already latest                |
 
 ### Bitcoin-specific flags
 
@@ -309,6 +326,8 @@ Always use `--json` for programmatic consumption. It disables ANSI colors and ou
 
 ### HD Wallet (`new` / `import`)
 
+With `-r` / `--reveal` (secrets included):
+
 ```json
 {
   "chain": "bitcoin",
@@ -327,7 +346,20 @@ Always use `--json` for programmatic consumption. It disables ANSI colors and ou
 }
 ```
 
+Without `--reveal`, `mnemonic` and each account's `private_key` are omitted.
 For EVM/SVM: `network` and `address_type` are omitted; `derivation_style` is included instead.
+
+### Upgrade (`upgrade` / `update`)
+
+```json
+{
+  "current": "3.0.0",
+  "latest": "3.0.0",
+  "update_available": false,
+  "action": "up_to_date",
+  "message": "kobe 3.0.0 is up to date"
+}
+```
 
 ### Camouflage (`encrypt` / `decrypt`)
 
@@ -462,9 +494,10 @@ Address: Bech32m-encoded compressed identity public key wrapped in a
 ## Agent Best Practices
 
 1. **Always use `--json`** for programmatic consumption to avoid ANSI escape codes.
-2. **Parse `private_key` by chain**: WIF for BTC, base58 keypair for SVM, hex for all others.
-3. **Use `--count`** to batch-derive multiple addresses in one call.
-4. **Mnemonic abbreviations** are auto-expanded: each BIP-39 word is uniquely identifiable by its first 4 characters (e.g., `aban` → `abandon`, `abou` → `about`).
-5. **Errors** in JSON mode return `{"error": "..."}` with exit code 1.
-6. **`--json` placement**: The flag must appear before the chain subcommand: `kobe --json btc new`, not `kobe btc --json new`.
+2. **Pass `-r` / `--reveal` when secrets are required**; default output omits mnemonic and private keys.
+3. **Parse `private_key` by chain**: WIF for BTC, base58 keypair for SVM, hex for all others.
+4. **Use `--count`** to batch-derive multiple addresses in one call.
+5. **Mnemonic abbreviations** are auto-expanded: each BIP-39 word is uniquely identifiable by its first 4 characters (e.g., `aban` → `abandon`, `abou` → `about`).
+6. **Errors** in JSON mode return `{"error": "..."}` with exit code 1.
 7. **Camouflage** is not the BIP-39 passphrase (25th word). It XOR-encrypts the mnemonic entropy itself using PBKDF2, producing a different but valid mnemonic.
+8. **Self-upgrade** for script installs: `kobe upgrade` (alias `update`); cargo installs need `cargo install kobe-cli --force`.


### PR DESCRIPTION
## Summary

- Add **`kobe upgrade`** (alias **`update`**) to re-run the official installer at `https://sh.qntx.fun/kobe` (PowerShell on Windows).
- **`--check`**: report current vs latest without installing.
- **`--force`**: reinstall even when already latest.
- **`--json`**: structured result for agents/scripts.
- Cargo installs (`.cargo/bin`) are not overwritten; prints `cargo install kobe-cli --force` instead.
- Naming: primary is **`upgrade`** (newer binary), `update` kept as alias (Deno/Bun-style; avoids apt’s “update = indexes” confusion).

### Docs

- README usage
- CHANGELOG `[Unreleased]`
- `docs/RELEASE.md` post-install note
- `skills/kobe/SKILL.md` (upgrade + `-r`/`--reveal` secrets defaults)
- `crates/README.md` kobe-cli row

## Naming note

| Name | Role |
| --- | --- |
| **upgrade** (primary) | Install a newer release of this binary |
| **update** (alias) | Same command; familiar synonym |

## Test plan

- [x] `just all` (fmt/clippy/no_std/deny)
- [x] `just test`
- [x] `kobe upgrade --help` shows primary name + docs
- [x] `kobe upgrade --check` / `kobe update --check` both work
- [x] Unit tests for tag parse + semver compare