### PR TITLE
release: v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this workspace are documented in this file. The format is
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-08-08
+
 ### Added
 
 - CLI `kobe upgrade` (`update` alias): self-upgrade via the official
@@ -15,6 +17,7 @@ All notable changes to this workspace are documented in this file. The format is
 - Replaced the `docs/` directory with a root [`CONTRIBUTING.md`](CONTRIBUTING.md)
   (API contract, development workflow, release process). Matches common Rust
   community layout.
+- Workspace crate versions bumped to **3.1.0**; lockfile refresh (`cc` 1.4.2).
 
 ## [3.0.0] - 2026-08-08
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,7 +181,7 @@ Maintainers only.
 3. Move `[Unreleased]` notes in `CHANGELOG.md` into a dated version section;
    no leftover **Breaking** bullets that belong in the release.
 4. Bump workspace `version` and path dependency major/minor strings in root
-   `Cargo.toml` (e.g. `3.0.0` → path `"3.0"`).
+   `Cargo.toml` (e.g. `3.1.0` → path `"3.1"`).
 5. Tag and push: `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`.
 6. Confirm GitHub Actions `release.yml` (binaries) and `publish.yml`
    (crates.io) succeed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,9 +201,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9066c49992464636f92905fa096ec58baaa4d57ec19a5c096c68d3e25ef3d136"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "kobe"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "kobe-aptos",
  "kobe-btc",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-aptos"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "hex",
  "kobe-primitives",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-btc"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "bech32",
  "bs58",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-cli"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "clap",
  "colored",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-cosmos"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "bech32",
  "kobe-primitives",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-evm"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "alloy-primitives",
  "kobe-primitives",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-fil"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "blake2",
  "kobe-primitives",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-nostr"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "bech32",
  "kobe-primitives",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-primitives"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "bip32",
  "bip39",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-spark"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "bech32",
  "hex",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-sui"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "blake2",
  "hex",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-svm"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "bs58",
  "kobe-primitives",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-ton"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "base64",
  "kobe-primitives",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-tron"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "bs58",
  "kobe-primitives",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-xrpl"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "bs58",
  "kobe-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["fuzz"]
 resolver = "3"
 
 [workspace.package]
-version = "3.0.0"
+version = "3.1.0"
 edition = "2024"
 # Minimum supported Rust version. `edition = "2024"` was stabilized in 1.85;
 # we pin to 1.85 here and enforce it in CI. Bumping this is a breaking change.
@@ -19,20 +19,20 @@ keywords = ["crypto", "wallet", "bitcoin", "ethereum", "solana"]
 categories = ["cryptography::cryptocurrencies"]
 
 [workspace.dependencies]
-kobe-primitives = { version = "3.0", path = "crates/kobe-primitives", default-features = false }
-kobe = { version = "3.0", path = "crates/kobe", default-features = false }
-kobe-btc = { version = "3.0", path = "crates/kobe-btc", default-features = false }
-kobe-cosmos = { version = "3.0", path = "crates/kobe-cosmos", default-features = false }
-kobe-evm = { version = "3.0", path = "crates/kobe-evm", default-features = false }
-kobe-fil = { version = "3.0", path = "crates/kobe-fil", default-features = false }
-kobe-spark = { version = "3.0", path = "crates/kobe-spark", default-features = false }
-kobe-sui = { version = "3.0", path = "crates/kobe-sui", default-features = false }
-kobe-svm = { version = "3.0", path = "crates/kobe-svm", default-features = false }
-kobe-ton = { version = "3.0", path = "crates/kobe-ton", default-features = false }
-kobe-tron = { version = "3.0", path = "crates/kobe-tron", default-features = false }
-kobe-aptos = { version = "3.0", path = "crates/kobe-aptos", default-features = false }
-kobe-nostr = { version = "3.0", path = "crates/kobe-nostr", default-features = false }
-kobe-xrpl = { version = "3.0", path = "crates/kobe-xrpl", default-features = false }
+kobe-primitives = { version = "3.1", path = "crates/kobe-primitives", default-features = false }
+kobe = { version = "3.1", path = "crates/kobe", default-features = false }
+kobe-btc = { version = "3.1", path = "crates/kobe-btc", default-features = false }
+kobe-cosmos = { version = "3.1", path = "crates/kobe-cosmos", default-features = false }
+kobe-evm = { version = "3.1", path = "crates/kobe-evm", default-features = false }
+kobe-fil = { version = "3.1", path = "crates/kobe-fil", default-features = false }
+kobe-spark = { version = "3.1", path = "crates/kobe-spark", default-features = false }
+kobe-sui = { version = "3.1", path = "crates/kobe-sui", default-features = false }
+kobe-svm = { version = "3.1", path = "crates/kobe-svm", default-features = false }
+kobe-ton = { version = "3.1", path = "crates/kobe-ton", default-features = false }
+kobe-tron = { version = "3.1", path = "crates/kobe-tron", default-features = false }
+kobe-aptos = { version = "3.1", path = "crates/kobe-aptos", default-features = false }
+kobe-nostr = { version = "3.1", path = "crates/kobe-nostr", default-features = false }
+kobe-xrpl = { version = "3.1", path = "crates/kobe-xrpl", default-features = false }
 
 alloy-primitives = { version = "1.6.1", default-features = false, features = ["k256"] }
 base64 = { version = "0.23.1", default-features = false, features = ["alloc"] }

--- a/crates/kobe/src/lib.rs
+++ b/crates/kobe/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! kobe = { version = "3.0", features = ["evm", "btc", "svm"] }
+//! kobe = { version = "3.1", features = ["evm", "btc", "svm"] }
 //! ```
 //!
 //! ```no_run

--- a/skills/kobe/SKILL.md
+++ b/skills/kobe/SKILL.md
@@ -353,8 +353,8 @@ For EVM/SVM: `network` and `address_type` are omitted; `derivation_style` is inc
 
 ```json
 {
-  "current": "3.0.0",
-  "latest": "3.0.0",
+  "current": "3.1.0",
+  "latest": "3.1.0",
   "update_available": false,
   "action": "up_to_date",
   "message": "kobe 3.0.0 is up to date"


### PR DESCRIPTION
## Summary

Release **v3.1.0** of the entire workspace (all crates use `version.workspace = true`).

### Included since v3.0.0

- **Added:** `kobe upgrade` / `update` self-upgrade via sh.qntx.fun
- **Changed:** root `CONTRIBUTING.md` replaces `docs/`
- Workspace version **3.1.0**, path deps `"3.1"`, lockfile refresh

### Dependency pins

Direct deps already on latest stable; intentional holds remain (`k256` 0.13, `bip32` 0.5, no blake2 rc).

## Test plan

- [x] `cargo test --workspace --all-features`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `kobe --version` → 3.1.0

## After merge

Tag `v3.1.0` and push to trigger release + crates.io publish workflows.