### PR TITLE
style: align TOML configs across the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,217 +1,217 @@
 [workspace]
-members = ["crates/*"]
+members         = ["crates/*"]
 default-members = ["crates/kobe"]
 # `fuzz/` lives outside the main workspace so its nightly-only dependencies
 # (`libfuzzer-sys`, `cargo-fuzz`) never leak into the stable build graph.
-exclude = ["fuzz"]
-resolver = "3"
+exclude         = ["fuzz"]
+resolver        = "3"
 
 [workspace.package]
-version = "3.1.0"
-edition = "2024"
+version      = "3.1.0"
+edition      = "2024"
 # Minimum supported Rust version. `edition = "2024"` was stabilized in 1.85;
 # we pin to 1.85 here and enforce it in CI. Bumping this is a breaking change.
 rust-version = "1.85"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/qntx/kobe"
-description = "Multi-chain HD wallet derivation library"
-keywords = ["crypto", "wallet", "bitcoin", "ethereum", "solana"]
-categories = ["cryptography::cryptocurrencies"]
+license      = "MIT OR Apache-2.0"
+repository   = "https://github.com/qntx/kobe"
+description  = "Multi-chain HD wallet derivation library"
+keywords     = ["crypto", "wallet", "bitcoin", "ethereum", "solana"]
+categories   = ["cryptography::cryptocurrencies"]
 
 [workspace.dependencies]
 kobe-primitives = { version = "3.1", path = "crates/kobe-primitives", default-features = false }
-kobe = { version = "3.1", path = "crates/kobe", default-features = false }
-kobe-btc = { version = "3.1", path = "crates/kobe-btc", default-features = false }
-kobe-cosmos = { version = "3.1", path = "crates/kobe-cosmos", default-features = false }
-kobe-evm = { version = "3.1", path = "crates/kobe-evm", default-features = false }
-kobe-fil = { version = "3.1", path = "crates/kobe-fil", default-features = false }
-kobe-spark = { version = "3.1", path = "crates/kobe-spark", default-features = false }
-kobe-sui = { version = "3.1", path = "crates/kobe-sui", default-features = false }
-kobe-svm = { version = "3.1", path = "crates/kobe-svm", default-features = false }
-kobe-ton = { version = "3.1", path = "crates/kobe-ton", default-features = false }
-kobe-tron = { version = "3.1", path = "crates/kobe-tron", default-features = false }
-kobe-aptos = { version = "3.1", path = "crates/kobe-aptos", default-features = false }
-kobe-nostr = { version = "3.1", path = "crates/kobe-nostr", default-features = false }
-kobe-xrpl = { version = "3.1", path = "crates/kobe-xrpl", default-features = false }
+kobe            = { version = "3.1", path = "crates/kobe",            default-features = false }
+kobe-btc        = { version = "3.1", path = "crates/kobe-btc",        default-features = false }
+kobe-cosmos     = { version = "3.1", path = "crates/kobe-cosmos",     default-features = false }
+kobe-evm        = { version = "3.1", path = "crates/kobe-evm",        default-features = false }
+kobe-fil        = { version = "3.1", path = "crates/kobe-fil",        default-features = false }
+kobe-spark      = { version = "3.1", path = "crates/kobe-spark",      default-features = false }
+kobe-sui        = { version = "3.1", path = "crates/kobe-sui",        default-features = false }
+kobe-svm        = { version = "3.1", path = "crates/kobe-svm",        default-features = false }
+kobe-ton        = { version = "3.1", path = "crates/kobe-ton",        default-features = false }
+kobe-tron       = { version = "3.1", path = "crates/kobe-tron",       default-features = false }
+kobe-aptos      = { version = "3.1", path = "crates/kobe-aptos",      default-features = false }
+kobe-nostr      = { version = "3.1", path = "crates/kobe-nostr",      default-features = false }
+kobe-xrpl       = { version = "3.1", path = "crates/kobe-xrpl",       default-features = false }
 
-alloy-primitives = { version = "1.6.1", default-features = false, features = ["k256"] }
-base64 = { version = "0.23.1", default-features = false, features = ["alloc"] }
-bech32 = { version = "0.12.0", default-features = false, features = ["alloc"] }
-bip32 = { version = "0.5.3", default-features = false, features = ["secp256k1", "alloc"] }
-bip39 = { version = "2.2.2", default-features = false }
-blake2 = { version = "0.10.6", default-features = false }
-bs58 = { version = "0.5.1", default-features = false, features = ["alloc"] }
-ed25519-dalek = { version = "3.0.0", default-features = false }
-hex = { version = "0.4.3", default-features = false }
-hmac = { version = "0.13.0", default-features = false }
+alloy-primitives = { version = "1.6.1",  default-features = false, features = ["k256"] }
+base64           = { version = "0.23.1", default-features = false, features = ["alloc"] }
+bech32           = { version = "0.12.0", default-features = false, features = ["alloc"] }
+bip32            = { version = "0.5.3",  default-features = false, features = ["secp256k1", "alloc"] }
+bip39            = { version = "2.2.2",  default-features = false }
+blake2           = { version = "0.10.6", default-features = false }
+bs58             = { version = "0.5.1",  default-features = false, features = ["alloc"] }
+ed25519-dalek    = { version = "3.0.0",  default-features = false }
+hex              = { version = "0.4.3",  default-features = false }
+hmac             = { version = "0.13.0", default-features = false }
 # Pinned to 0.13.x: bip32 0.5 and alloy-primitives still depend on k256 0.13.
 # Bump when those crates publish k256 0.14 support (bip32 0.6 is still pre-release).
-k256 = { version = "0.13.4", default-features = false, features = ["ecdsa"] }
-ripemd = { version = "0.2.0", default-features = false }
-sha2 = { version = "0.11.0", default-features = false }
-sha3 = { version = "0.12.0", default-features = false }
-thiserror = { version = "2.0.19", default-features = false }
-zeroize = { version = "1.9.0", default-features = false, features = ["derive"] }
+k256             = { version = "0.13.4", default-features = false, features = ["ecdsa"] }
+ripemd           = { version = "0.2.0",  default-features = false }
+sha2             = { version = "0.11.0", default-features = false }
+sha3             = { version = "0.12.0", default-features = false }
+thiserror        = { version = "2.0.19", default-features = false }
+zeroize          = { version = "1.9.0",  default-features = false, features = ["derive"] }
 
-clap = { version = "4.6.6", features = ["derive"] }
-colored = "3.1.1"
-qrcode = "0.14.1"
-serde = { version = "1.0.229", features = ["derive"] }
+clap       = { version = "4.6.6", features = ["derive"] }
+colored    = "3.1.1"
+qrcode     = "0.14.1"
+serde      = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 
 [profile.release]
 codegen-units = 1
-lto = "thin"
-panic = "abort"
-strip = true
+lto           = "thin"
+panic         = "abort"
+strip         = true
 
 [profile.dev]
-debug = true
+debug     = true
 opt-level = 0
 
 [profile.test]
 opt-level = 2
 
 [profile.ci]
-debug = false
+debug    = false
 inherits = "dev"
 
 [profile.bench]
-debug = true
+debug    = true
 inherits = "release"
 
 [workspace.lints.rust]
-unsafe_code = "deny"
-elided_lifetimes_in_paths = "warn"
-single_use_lifetimes = "warn"
-unused_lifetimes = "warn"
-missing_copy_implementations = "warn"
+unsafe_code                   = "deny"
+elided_lifetimes_in_paths     = "warn"
+single_use_lifetimes          = "warn"
+unused_lifetimes              = "warn"
+missing_copy_implementations  = "warn"
 missing_debug_implementations = "warn"
-missing_docs = "warn"
-trivial_casts = "warn"
-trivial_numeric_casts = "warn"
-variant_size_differences = "warn"
-unused_qualifications = "warn"
-unused_imports = "warn"
-unused_macro_rules = "warn"
-unused_must_use = "deny"
-unreachable_pub = "warn"
-unused_crate_dependencies = "warn"
-non_ascii_idents = "deny"
-non_camel_case_types = "warn"
-non_snake_case = "warn"
-non_upper_case_globals = "warn"
-keyword_idents = { level = "warn", priority = -1 }
-macro_use_extern_crate = "warn"
-meta_variable_misuse = "warn"
-rust_2018_idioms = { level = "deny", priority = -1 }
-rust_2024_compatibility = { level = "warn", priority = -1 }
+missing_docs                  = "warn"
+trivial_casts                 = "warn"
+trivial_numeric_casts         = "warn"
+variant_size_differences      = "warn"
+unused_qualifications         = "warn"
+unused_imports                = "warn"
+unused_macro_rules            = "warn"
+unused_must_use               = "deny"
+unreachable_pub               = "warn"
+unused_crate_dependencies     = "warn"
+non_ascii_idents              = "deny"
+non_camel_case_types          = "warn"
+non_snake_case                = "warn"
+non_upper_case_globals        = "warn"
+keyword_idents                = { level = "warn", priority = -1 }
+macro_use_extern_crate        = "warn"
+meta_variable_misuse          = "warn"
+rust_2018_idioms              = { level = "deny", priority = -1 }
+rust_2024_compatibility       = { level = "warn", priority = -1 }
 
 [workspace.lints.rustdoc]
-all = { level = "warn", priority = -1 }
-broken_intra_doc_links = "warn"
-private_intra_doc_links = "warn"
-missing_crate_level_docs = "warn"
+all                          = { level = "warn", priority = -1 }
+broken_intra_doc_links       = "warn"
+private_intra_doc_links      = "warn"
+missing_crate_level_docs     = "warn"
 invalid_codeblock_attributes = "warn"
-invalid_html_tags = "warn"
-invalid_rust_codeblocks = "warn"
-bare_urls = "warn"
-unescaped_backticks = "warn"
+invalid_html_tags            = "warn"
+invalid_rust_codeblocks      = "warn"
+bare_urls                    = "warn"
+unescaped_backticks          = "warn"
 
 [workspace.lints.clippy]
-correctness = { level = "deny", priority = -1 }
-suspicious = { level = "deny", priority = -1 }
-complexity = { level = "warn", priority = -1 }
-perf = { level = "warn", priority = -1 }
-style = { level = "warn", priority = -1 }
-pedantic = { level = "warn", priority = -1 }
-nursery = { level = "warn", priority = -1 }
-cargo = { level = "warn", priority = -1 }
-restriction = { level = "allow", priority = -1 }
+correctness                        = { level = "deny",  priority = -1 }
+suspicious                         = { level = "deny",  priority = -1 }
+complexity                         = { level = "warn",  priority = -1 }
+perf                               = { level = "warn",  priority = -1 }
+style                              = { level = "warn",  priority = -1 }
+pedantic                           = { level = "warn",  priority = -1 }
+nursery                            = { level = "warn",  priority = -1 }
+cargo                              = { level = "warn",  priority = -1 }
+restriction                        = { level = "allow", priority = -1 }
 
-dbg_macro = "warn"
-print_stderr = "warn"
-print_stdout = "warn"
-todo = "warn"
-unimplemented = "warn"
-panic = "warn"
-unwrap_used = "warn"
-unwrap_in_result = "warn"
-expect_used = "warn"
-panic_in_result_fn = "warn"
-indexing_slicing = "warn"
-exit = "warn"
+dbg_macro                          = "warn"
+print_stderr                       = "warn"
+print_stdout                       = "warn"
+todo                               = "warn"
+unimplemented                      = "warn"
+panic                              = "warn"
+unwrap_used                        = "warn"
+unwrap_in_result                   = "warn"
+expect_used                        = "warn"
+panic_in_result_fn                 = "warn"
+indexing_slicing                   = "warn"
+exit                               = "warn"
 
-undocumented_unsafe_blocks = "warn"
-multiple_unsafe_ops_per_block = "warn"
-mem_forget = "warn"
-clone_on_ref_ptr = "warn"
-rc_buffer = "warn"
-rc_mutex = "warn"
+undocumented_unsafe_blocks         = "warn"
+multiple_unsafe_ops_per_block      = "warn"
+mem_forget                         = "warn"
+clone_on_ref_ptr                   = "warn"
+rc_buffer                          = "warn"
+rc_mutex                           = "warn"
 
-fallible_impl_from = "warn"
-error_impl_error = "warn"
-let_underscore_must_use = "warn"
+fallible_impl_from                 = "warn"
+error_impl_error                   = "warn"
+let_underscore_must_use            = "warn"
 
-rest_pat_in_fully_bound_structs = "warn"
-fn_params_excessive_bools = "warn"
-struct_excessive_bools = "warn"
-large_types_passed_by_value = "warn"
-implicit_hasher = "warn"
-redundant_type_annotations = "warn"
+rest_pat_in_fully_bound_structs    = "warn"
+fn_params_excessive_bools          = "warn"
+struct_excessive_bools             = "warn"
+large_types_passed_by_value        = "warn"
+implicit_hasher                    = "warn"
+redundant_type_annotations         = "warn"
 
-str_to_string = "warn"
-string_lit_as_bytes = "warn"
-needless_raw_string_hashes = "warn"
-format_push_string = "warn"
+str_to_string                      = "warn"
+string_lit_as_bytes                = "warn"
+needless_raw_string_hashes         = "warn"
+format_push_string                 = "warn"
 
-cast_possible_truncation = "warn"
-cast_sign_loss = "warn"
-cast_lossless = "warn"
-as_underscore = "warn"
-cast_precision_loss = "allow"
+cast_possible_truncation           = "warn"
+cast_sign_loss                     = "warn"
+cast_lossless                      = "warn"
+as_underscore                      = "warn"
+cast_precision_loss                = "allow"
 
-future_not_send = "warn"
-await_holding_lock = "warn"
-await_holding_refcell_ref = "warn"
-significant_drop_tightening = "warn"
+future_not_send                    = "warn"
+await_holding_lock                 = "warn"
+await_holding_refcell_ref          = "warn"
+significant_drop_tightening        = "warn"
 
 match_wildcard_for_single_variants = "warn"
-match_same_arms = "warn"
-option_if_let_else = "warn"
-wildcard_enum_match_arm = "allow"
+match_same_arms                    = "warn"
+option_if_let_else                 = "warn"
+wildcard_enum_match_arm            = "allow"
 
-cognitive_complexity = "warn"
-too_many_lines = "warn"
-excessive_nesting = "warn"
+cognitive_complexity               = "warn"
+too_many_lines                     = "warn"
+excessive_nesting                  = "warn"
 
-used_underscore_binding = "warn"
-verbose_file_reads = "warn"
-tests_outside_test_module = "warn"
-unnecessary_self_imports = "warn"
-infinite_loop = "warn"
-allow_attributes_without_reason = "warn"
-missing_assert_message = "warn"
-empty_line_after_doc_comments = "warn"
-empty_line_after_outer_attr = "warn"
+used_underscore_binding            = "warn"
+verbose_file_reads                 = "warn"
+tests_outside_test_module          = "warn"
+unnecessary_self_imports           = "warn"
+infinite_loop                      = "warn"
+allow_attributes_without_reason    = "warn"
+missing_assert_message             = "warn"
+empty_line_after_doc_comments      = "warn"
+empty_line_after_outer_attr        = "warn"
 
-missing_docs_in_private_items = "allow"
-missing_errors_doc = "warn"
-missing_panics_doc = "warn"
-missing_safety_doc = "warn"
-doc_markdown = "warn"
-must_use_candidate = "warn"
-return_self_not_must_use = "warn"
+missing_docs_in_private_items      = "allow"
+missing_errors_doc                 = "warn"
+missing_panics_doc                 = "warn"
+missing_safety_doc                 = "warn"
+doc_markdown                       = "warn"
+must_use_candidate                 = "warn"
+return_self_not_must_use           = "warn"
 
-exhaustive_enums = "allow"
-exhaustive_structs = "allow"
-module_name_repetitions = "allow"
-similar_names = "allow"
-shadow_reuse = "allow"
-shadow_same = "allow"
-shadow_unrelated = "warn"
-multiple_crate_versions = "allow"
-cargo_common_metadata = "allow"
-semicolon_inside_block = "allow"
-semicolon_outside_block = "allow"
-redundant_pub_crate = "allow"
+exhaustive_enums                   = "allow"
+exhaustive_structs                 = "allow"
+module_name_repetitions            = "allow"
+similar_names                      = "allow"
+shadow_reuse                       = "allow"
+shadow_same                        = "allow"
+shadow_unrelated                   = "warn"
+multiple_crate_versions            = "allow"
+cargo_common_metadata              = "allow"
+semicolon_inside_block             = "allow"
+semicolon_outside_block            = "allow"
+redundant_pub_crate                = "allow"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,14 +1,14 @@
 cognitive-complexity-threshold = 20
-excessive-nesting-threshold = 4
-too-many-lines-threshold = 120
-too-many-arguments-threshold = 7
-type-complexity-threshold = 250
-struct-field-name-threshold = 8
-enum-variant-size-threshold = 200
+excessive-nesting-threshold    = 4
+too-many-lines-threshold       = 120
+too-many-arguments-threshold   = 7
+type-complexity-threshold      = 250
+struct-field-name-threshold    = 8
+enum-variant-size-threshold    = 200
 
 single-char-binding-names-threshold = 4
-min-ident-chars-threshold = 2
-allowed-idents-below-min-chars = [
+min-ident-chars-threshold           = 2
+allowed-idents-below-min-chars      = [
     "i",
     "j",
     "k",
@@ -24,15 +24,15 @@ allowed-idents-below-min-chars = [
 ]
 
 pass-by-value-size-limit = 128
-trivial-copy-size-limit = 8
+trivial-copy-size-limit  = 8
 
 large-error-threshold = 128
 
 avoid-breaking-exported-api = true
-check-private-items = false
+check-private-items         = false
 
-allow-dbg-in-tests = true
-allow-print-in-tests = true
+allow-dbg-in-tests    = true
+allow-print-in-tests  = true
 allow-unwrap-in-tests = true
 allow-expect-in-tests = true
 

--- a/crates/kobe-aptos/Cargo.toml
+++ b/crates/kobe-aptos/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
-name = "kobe-aptos"
-version.workspace = true
-edition.workspace = true
+name                   = "kobe-aptos"
+version.workspace      = true
+edition.workspace      = true
 rust-version.workspace = true
-license.workspace = true
-repository.workspace = true
-readme = "../../README.md"
-description = "Aptos wallet for Kobe"
-keywords = ["aptos", "wallet", "crypto", "no_std"]
-categories = ["cryptography", "no-std"]
+license.workspace      = true
+repository.workspace   = true
+readme                 = "../../README.md"
+description            = "Aptos wallet for Kobe"
+keywords               = ["aptos", "wallet", "crypto", "no_std"]
+categories             = ["cryptography", "no-std"]
 
 [features]
 default = ["std"]
-std = ["alloc", "kobe-primitives/std", "hex/std", "zeroize/std"]
-alloc = ["kobe-primitives/alloc", "hex/alloc", "zeroize/alloc"]
+std     = ["alloc", "kobe-primitives/std", "hex/std", "zeroize/std"]
+alloc   = ["kobe-primitives/alloc", "hex/alloc", "zeroize/alloc"]
 
 [dependencies]
-kobe-primitives = { workspace = true, features = ["slip10"] }
-hex.workspace = true
-sha3.workspace = true
+kobe-primitives   = { workspace = true, features = ["slip10"] }
+hex.workspace     = true
+sha3.workspace    = true
 zeroize.workspace = true
 
 [lints]

--- a/crates/kobe-btc/Cargo.toml
+++ b/crates/kobe-btc/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
-name = "kobe-btc"
-version.workspace = true
-edition.workspace = true
+name                   = "kobe-btc"
+version.workspace      = true
+edition.workspace      = true
 rust-version.workspace = true
-license.workspace = true
-repository.workspace = true
-readme = "../../README.md"
-description = "Bitcoin HD wallet derivation for Kobe"
-keywords = ["bitcoin", "wallet", "crypto", "no_std"]
-categories = ["cryptography", "no-std"]
+license.workspace      = true
+repository.workspace   = true
+readme                 = "../../README.md"
+description            = "Bitcoin HD wallet derivation for Kobe"
+keywords               = ["bitcoin", "wallet", "crypto", "no_std"]
+categories             = ["cryptography", "no-std"]
 
 [features]
 default = ["std"]
-std = ["alloc", "kobe-primitives/std", "zeroize/std"]
-alloc = ["kobe-primitives/alloc", "zeroize/alloc"]
+std     = ["alloc", "kobe-primitives/std", "zeroize/std"]
+alloc   = ["kobe-primitives/alloc", "zeroize/alloc"]
 
 [dependencies]
-bech32.workspace = true
-kobe-primitives = { workspace = true, features = ["bip32", "encoding"] }
-k256.workspace = true
-sha2.workspace = true
+bech32.workspace  = true
+kobe-primitives   = { workspace = true, features = ["bip32", "encoding"] }
+k256.workspace    = true
+sha2.workspace    = true
 zeroize.workspace = true
 
 [dev-dependencies]
 bs58.workspace = true
-hex.workspace = true
+hex.workspace  = true
 
 [lints]
 workspace = true

--- a/crates/kobe-cli/Cargo.toml
+++ b/crates/kobe-cli/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "kobe-cli"
-version.workspace = true
-edition.workspace = true
+name                   = "kobe-cli"
+version.workspace      = true
+edition.workspace      = true
 rust-version.workspace = true
-license.workspace = true
-repository.workspace = true
-readme = "../../README.md"
-description = "A multi-chain cryptocurrency wallet CLI tool"
-keywords = ["crypto", "wallet", "bitcoin", "ethereum", "cli"]
-categories = ["command-line-utilities", "cryptography"]
+license.workspace      = true
+repository.workspace   = true
+readme                 = "../../README.md"
+description            = "A multi-chain cryptocurrency wallet CLI tool"
+keywords               = ["crypto", "wallet", "bitcoin", "ethereum", "cli"]
+categories             = ["command-line-utilities", "cryptography"]
 
 [[bin]]
 name = "kobe"
@@ -18,11 +18,11 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-kobe = { workspace = true, features = ["std", "rand", "camouflage", "all-chains"] }
-clap.workspace = true
-colored.workspace = true
-qrcode.workspace = true
-serde.workspace = true
+kobe                 = { workspace = true, features = ["std", "rand", "camouflage", "all-chains"] }
+clap.workspace       = true
+colored.workspace    = true
+qrcode.workspace     = true
+serde.workspace      = true
 serde_json.workspace = true
 
 [lints]

--- a/crates/kobe-cosmos/Cargo.toml
+++ b/crates/kobe-cosmos/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
-name = "kobe-cosmos"
-version.workspace = true
-edition.workspace = true
+name                   = "kobe-cosmos"
+version.workspace      = true
+edition.workspace      = true
 rust-version.workspace = true
-license.workspace = true
-repository.workspace = true
-readme = "../../README.md"
-description = "Cosmos wallet for Kobe"
-keywords = ["cosmos", "wallet", "crypto", "no_std"]
-categories = ["cryptography", "no-std"]
+license.workspace      = true
+repository.workspace   = true
+readme                 = "../../README.md"
+description            = "Cosmos wallet for Kobe"
+keywords               = ["cosmos", "wallet", "crypto", "no_std"]
+categories             = ["cryptography", "no-std"]
 
 [features]
 default = ["std"]
-std = ["alloc", "kobe-primitives/std"]
-alloc = ["kobe-primitives/alloc"]
+std     = ["alloc", "kobe-primitives/std"]
+alloc   = ["kobe-primitives/alloc"]
 
 [dependencies]
-kobe-primitives = { workspace = true, features = ["bip32", "encoding"] }
+kobe-primitives  = { workspace = true, features = ["bip32", "encoding"] }
 bech32.workspace = true
 
 [lints]

--- a/crates/kobe-evm/Cargo.toml
+++ b/crates/kobe-evm/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
-name = "kobe-evm"
-version.workspace = true
-edition.workspace = true
+name                   = "kobe-evm"
+version.workspace      = true
+edition.workspace      = true
 rust-version.workspace = true
-license.workspace = true
-repository.workspace = true
-readme = "../../README.md"
-description = "Ethereum HD wallet derivation for Kobe"
-keywords = ["ethereum", "wallet", "crypto", "no_std"]
-categories = ["cryptography", "no-std"]
+license.workspace      = true
+repository.workspace   = true
+readme                 = "../../README.md"
+description            = "Ethereum HD wallet derivation for Kobe"
+keywords               = ["ethereum", "wallet", "crypto", "no_std"]
+categories             = ["cryptography", "no-std"]
 
 [features]
 default = ["std"]
-std = ["alloc", "kobe-primitives/std"]
-alloc = ["kobe-primitives/alloc"]
+std     = ["alloc", "kobe-primitives/std"]
+alloc   = ["kobe-primitives/alloc"]
 
 [dependencies]
-kobe-primitives = { workspace = true, features = ["bip32"] }
+kobe-primitives            = { workspace = true, features = ["bip32"] }
 alloy-primitives.workspace = true
 
 [lints]

--- a/crates/kobe-fil/Cargo.toml
+++ b/crates/kobe-fil/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
-name = "kobe-fil"
-version.workspace = true
-edition.workspace = true
+name                   = "kobe-fil"
+version.workspace      = true
+edition.workspace      = true
 rust-version.workspace = true
-license.workspace = true
-repository.workspace = true
-readme = "../../README.md"
-description = "Filecoin wallet for Kobe"
-keywords = ["filecoin", "wallet", "crypto", "no_std"]
-categories = ["cryptography", "no-std"]
+license.workspace      = true
+repository.workspace   = true
+readme                 = "../../README.md"
+description            = "Filecoin wallet for Kobe"
+keywords               = ["filecoin", "wallet", "crypto", "no_std"]
+categories             = ["cryptography", "no-std"]
 
 [features]
 default = ["std"]
-std = ["alloc", "kobe-primitives/std"]
-alloc = ["kobe-primitives/alloc"]
+std     = ["alloc", "kobe-primitives/std"]
+alloc   = ["kobe-primitives/alloc"]
 
 [dependencies]
-kobe-primitives = { workspace = true, features = ["bip32"] }
+kobe-primitives  = { workspace = true, features = ["bip32"] }
 blake2.workspace = true
 
 [lints]

--- a/crates/kobe-nostr/Cargo.toml
+++ b/crates/kobe-nostr/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name = "kobe-nostr"
-version.workspace = true
-edition.workspace = true
+name                   = "kobe-nostr"
+version.workspace      = true
+edition.workspace      = true
 rust-version.workspace = true
-license.workspace = true
-repository.workspace = true
-readme = "../../README.md"
-description = "Nostr wallet for Kobe"
-keywords = ["nostr", "wallet", "crypto", "no_std"]
-categories = ["cryptography", "no-std"]
+license.workspace      = true
+repository.workspace   = true
+readme                 = "../../README.md"
+description            = "Nostr wallet for Kobe"
+keywords               = ["nostr", "wallet", "crypto", "no_std"]
+categories             = ["cryptography", "no-std"]
 
 [features]
 default = ["std"]
-std = ["alloc", "kobe-primitives/std", "zeroize/std"]
-alloc = ["kobe-primitives/alloc", "zeroize/alloc"]
+std     = ["alloc", "kobe-primitives/std", "zeroize/std"]
+alloc   = ["kobe-primitives/alloc", "zeroize/alloc"]
 
 [dependencies]
-kobe-primitives = { workspace = true, features = ["bip32"] }
-bech32.workspace = true
+kobe-primitives   = { workspace = true, features = ["bip32"] }
+bech32.workspace  = true
 zeroize.workspace = true
 
 [lints]

--- a/crates/kobe-primitives/Cargo.toml
+++ b/crates/kobe-primitives/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
-name = "kobe-primitives"
-version.workspace = true
-edition.workspace = true
+name                   = "kobe-primitives"
+version.workspace      = true
+edition.workspace      = true
 rust-version.workspace = true
-license.workspace = true
-repository.workspace = true
-readme = "../../README.md"
-description = "Multi-chain HD wallet derivation library"
-keywords = ["crypto", "wallet", "bip39", "mnemonic", "no_std"]
-categories = ["cryptography", "no-std"]
+license.workspace      = true
+repository.workspace   = true
+readme                 = "../../README.md"
+description            = "Multi-chain HD wallet derivation library"
+keywords               = ["crypto", "wallet", "bip39", "mnemonic", "no_std"]
+categories             = ["cryptography", "no-std"]
 
 [features]
-default = ["std"]
-std = ["alloc", "bip39/std", "zeroize/std"]
-alloc = ["bip39/alloc", "dep:hex", "dep:zeroize", "zeroize/alloc"]
-rand = ["bip39/rand"]
-rand_core = ["bip39/rand_core"]
+default    = ["std"]
+std        = ["alloc", "bip39/std", "zeroize/std"]
+alloc      = ["bip39/alloc", "dep:hex", "dep:zeroize", "zeroize/alloc"]
+rand       = ["bip39/rand"]
+rand_core  = ["bip39/rand_core"]
 camouflage = ["dep:hmac", "dep:sha2", "alloc"]
-slip10 = ["dep:ed25519-dalek", "dep:hmac", "dep:sha2", "alloc"]
-bip32 = ["dep:bip32-crate", "dep:k256", "alloc"]
+slip10     = ["dep:ed25519-dalek", "dep:hmac", "dep:sha2", "alloc"]
+bip32      = ["dep:bip32-crate", "dep:k256", "alloc"]
 # Shared hash160 / Base58Check helpers for chain address encoding.
 encoding = ["alloc", "dep:sha2", "dep:ripemd", "dep:bs58"]
 # Escape hatch: expose [`Wallet::seed`]. Prefer `derive_secp256k1` /
@@ -31,17 +31,17 @@ raw-seed = []
 test-vectors = []
 
 [dependencies]
-bip39.workspace = true
-hmac = { workspace = true, optional = true }
-sha2 = { workspace = true, optional = true }
-ripemd = { workspace = true, optional = true }
-bs58 = { workspace = true, optional = true }
-ed25519-dalek = { workspace = true, optional = true }
-bip32-crate = { package = "bip32", version = "0.5.3", default-features = false, features = ["secp256k1", "alloc"], optional = true }
-k256 = { workspace = true, optional = true }
-hex = { version = "0.4.3", default-features = false, features = ["alloc"], optional = true }
+bip39.workspace     = true
+hmac                = { workspace = true, optional = true }
+sha2                = { workspace = true, optional = true }
+ripemd              = { workspace = true, optional = true }
+bs58                = { workspace = true, optional = true }
+ed25519-dalek       = { workspace = true, optional = true }
+bip32-crate         = { package = "bip32", version = "0.5.3", default-features = false, features = ["secp256k1", "alloc"], optional = true }
+k256                = { workspace = true, optional = true }
+hex                 = { version = "0.4.3", default-features = false, features = ["alloc"], optional = true }
 thiserror.workspace = true
-zeroize = { workspace = true, optional = true }
+zeroize             = { workspace = true, optional = true }
 
 [dev-dependencies]
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }

--- a/crates/kobe-spark/Cargo.toml
+++ b/crates/kobe-spark/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
-name = "kobe-spark"
-version.workspace = true
-edition.workspace = true
+name                   = "kobe-spark"
+version.workspace      = true
+edition.workspace      = true
 rust-version.workspace = true
-license.workspace = true
-repository.workspace = true
-readme = "../../README.md"
-description = "Spark (Bitcoin L2) wallet for Kobe"
-keywords = ["spark", "bitcoin", "wallet", "crypto"]
-categories = ["cryptography", "no-std"]
+license.workspace      = true
+repository.workspace   = true
+readme                 = "../../README.md"
+description            = "Spark (Bitcoin L2) wallet for Kobe"
+keywords               = ["spark", "bitcoin", "wallet", "crypto"]
+categories             = ["cryptography", "no-std"]
 
 [features]
 default = ["std"]
-std = ["alloc", "kobe-primitives/std"]
-alloc = ["kobe-primitives/alloc"]
+std     = ["alloc", "kobe-primitives/std"]
+alloc   = ["kobe-primitives/alloc"]
 
 [dependencies]
-kobe-primitives = { workspace = true, features = ["bip32"] }
+kobe-primitives  = { workspace = true, features = ["bip32"] }
 bech32.workspace = true
 
 [dev-dependencies]

--- a/crates/kobe-sui/Cargo.toml
+++ b/crates/kobe-sui/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
-name = "kobe-sui"
-version.workspace = true
-edition.workspace = true
+name                   = "kobe-sui"
+version.workspace      = true
+edition.workspace      = true
 rust-version.workspace = true
-license.workspace = true
-repository.workspace = true
-readme = "../../README.md"
-description = "Sui wallet for Kobe"
-keywords = ["sui", "wallet", "crypto", "no_std"]
-categories = ["cryptography", "no-std"]
+license.workspace      = true
+repository.workspace   = true
+readme                 = "../../README.md"
+description            = "Sui wallet for Kobe"
+keywords               = ["sui", "wallet", "crypto", "no_std"]
+categories             = ["cryptography", "no-std"]
 
 [features]
 default = ["std"]
-std = ["alloc", "kobe-primitives/std", "hex/std", "zeroize/std"]
-alloc = ["kobe-primitives/alloc", "hex/alloc", "zeroize/alloc"]
+std     = ["alloc", "kobe-primitives/std", "hex/std", "zeroize/std"]
+alloc   = ["kobe-primitives/alloc", "hex/alloc", "zeroize/alloc"]
 
 [dependencies]
-kobe-primitives = { workspace = true, features = ["slip10"] }
-hex.workspace = true
+kobe-primitives   = { workspace = true, features = ["slip10"] }
+hex.workspace     = true
 zeroize.workspace = true
-blake2.workspace = true
+blake2.workspace  = true
 
 [lints]
 workspace = true

--- a/crates/kobe-svm/Cargo.toml
+++ b/crates/kobe-svm/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name = "kobe-svm"
-version.workspace = true
-edition.workspace = true
+name                   = "kobe-svm"
+version.workspace      = true
+edition.workspace      = true
 rust-version.workspace = true
-license.workspace = true
-repository.workspace = true
-readme = "../../README.md"
-description = "Solana HD wallet derivation for Kobe"
-keywords = ["solana", "wallet", "crypto", "no_std"]
-categories = ["cryptography", "no-std"]
+license.workspace      = true
+repository.workspace   = true
+readme                 = "../../README.md"
+description            = "Solana HD wallet derivation for Kobe"
+keywords               = ["solana", "wallet", "crypto", "no_std"]
+categories             = ["cryptography", "no-std"]
 
 [features]
 default = ["std"]
-std = ["alloc", "kobe-primitives/std", "zeroize/std"]
-alloc = ["kobe-primitives/alloc", "zeroize/alloc"]
+std     = ["alloc", "kobe-primitives/std", "zeroize/std"]
+alloc   = ["kobe-primitives/alloc", "zeroize/alloc"]
 
 [dependencies]
-kobe-primitives = { workspace = true, features = ["slip10"] }
-bs58.workspace = true
+kobe-primitives   = { workspace = true, features = ["slip10"] }
+bs58.workspace    = true
 zeroize.workspace = true
 
 [lints]

--- a/crates/kobe-ton/Cargo.toml
+++ b/crates/kobe-ton/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
-name = "kobe-ton"
-version.workspace = true
-edition.workspace = true
+name                   = "kobe-ton"
+version.workspace      = true
+edition.workspace      = true
 rust-version.workspace = true
-license.workspace = true
-repository.workspace = true
-readme = "../../README.md"
-description = "TON wallet for Kobe"
-keywords = ["ton", "wallet", "crypto", "no_std"]
-categories = ["cryptography", "no-std"]
+license.workspace      = true
+repository.workspace   = true
+readme                 = "../../README.md"
+description            = "TON wallet for Kobe"
+keywords               = ["ton", "wallet", "crypto", "no_std"]
+categories             = ["cryptography", "no-std"]
 
 [features]
 default = ["std"]
-std = ["alloc", "kobe-primitives/std", "zeroize/std"]
-alloc = ["kobe-primitives/alloc", "zeroize/alloc"]
+std     = ["alloc", "kobe-primitives/std", "zeroize/std"]
+alloc   = ["kobe-primitives/alloc", "zeroize/alloc"]
 
 [dependencies]
-kobe-primitives = { workspace = true, features = ["slip10"] }
+kobe-primitives   = { workspace = true, features = ["slip10"] }
 zeroize.workspace = true
-sha2.workspace = true
-base64.workspace = true
+sha2.workspace    = true
+base64.workspace  = true
 
 [lints]
 workspace = true

--- a/crates/kobe-tron/Cargo.toml
+++ b/crates/kobe-tron/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
-name = "kobe-tron"
-version.workspace = true
-edition.workspace = true
+name                   = "kobe-tron"
+version.workspace      = true
+edition.workspace      = true
 rust-version.workspace = true
-license.workspace = true
-repository.workspace = true
-readme = "../../README.md"
-description = "Tron wallet for Kobe"
-keywords = ["tron", "wallet", "crypto", "no_std"]
-categories = ["cryptography", "no-std"]
+license.workspace      = true
+repository.workspace   = true
+readme                 = "../../README.md"
+description            = "Tron wallet for Kobe"
+keywords               = ["tron", "wallet", "crypto", "no_std"]
+categories             = ["cryptography", "no-std"]
 
 [features]
 default = ["std"]
-std = ["alloc", "kobe-primitives/std"]
-alloc = ["kobe-primitives/alloc"]
+std     = ["alloc", "kobe-primitives/std"]
+alloc   = ["kobe-primitives/alloc"]
 
 [dependencies]
 kobe-primitives = { workspace = true, features = ["bip32"] }
-sha3.workspace = true
-bs58 = { workspace = true, features = ["check"] }
+sha3.workspace  = true
+bs58            = { workspace = true, features = ["check"] }
 
 [lints]
 workspace = true

--- a/crates/kobe-xrpl/Cargo.toml
+++ b/crates/kobe-xrpl/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name = "kobe-xrpl"
-version.workspace = true
-edition.workspace = true
+name                   = "kobe-xrpl"
+version.workspace      = true
+edition.workspace      = true
 rust-version.workspace = true
-license.workspace = true
-repository.workspace = true
-readme = "../../README.md"
-description = "XRP Ledger wallet for Kobe"
-keywords = ["xrpl", "ripple", "wallet", "crypto", "no_std"]
-categories = ["cryptography", "no-std"]
+license.workspace      = true
+repository.workspace   = true
+readme                 = "../../README.md"
+description            = "XRP Ledger wallet for Kobe"
+keywords               = ["xrpl", "ripple", "wallet", "crypto", "no_std"]
+categories             = ["cryptography", "no-std"]
 
 [features]
 default = ["std"]
-std = ["alloc", "kobe-primitives/std"]
-alloc = ["kobe-primitives/alloc"]
+std     = ["alloc", "kobe-primitives/std"]
+alloc   = ["kobe-primitives/alloc"]
 
 [dependencies]
 kobe-primitives = { workspace = true, features = ["bip32", "encoding"] }
-bs58.workspace = true
+bs58.workspace  = true
 
 [lints]
 workspace = true

--- a/crates/kobe/Cargo.toml
+++ b/crates/kobe/Cargo.toml
@@ -1,42 +1,42 @@
 [package]
-name = "kobe"
-version.workspace = true
-edition.workspace = true
+name                   = "kobe"
+version.workspace      = true
+edition.workspace      = true
 rust-version.workspace = true
-license.workspace = true
-repository.workspace = true
-readme = "../../README.md"
-description = "Multi-chain HD wallet derivation — umbrella crate"
-keywords = ["crypto", "wallet", "bitcoin", "ethereum", "solana"]
-categories = ["cryptography::cryptocurrencies"]
+license.workspace      = true
+repository.workspace   = true
+readme                 = "../../README.md"
+description            = "Multi-chain HD wallet derivation — umbrella crate"
+keywords               = ["crypto", "wallet", "bitcoin", "ethereum", "solana"]
+categories             = ["cryptography::cryptocurrencies"]
 
 [features]
 # Minimal default: only `std` core. Opt into chains explicitly or via presets
 # (`mainstream`, `all-chains`) to keep binary size and compile time predictable.
 default = ["std"]
 
-std = ["alloc", "kobe-primitives/std", "kobe-aptos?/std", "kobe-btc?/std", "kobe-evm?/std", "kobe-svm?/std", "kobe-cosmos?/std", "kobe-tron?/std", "kobe-spark?/std", "kobe-fil?/std", "kobe-ton?/std", "kobe-sui?/std", "kobe-nostr?/std", "kobe-xrpl?/std"]
-alloc = ["kobe-primitives/alloc", "kobe-aptos?/alloc", "kobe-btc?/alloc", "kobe-evm?/alloc", "kobe-svm?/alloc", "kobe-cosmos?/alloc", "kobe-tron?/alloc", "kobe-spark?/alloc", "kobe-fil?/alloc", "kobe-ton?/alloc", "kobe-sui?/alloc", "kobe-nostr?/alloc", "kobe-xrpl?/alloc"]
-rand = ["kobe-primitives/rand"]
-rand_core = ["kobe-primitives/rand_core"]
+std        = ["alloc", "kobe-primitives/std", "kobe-aptos?/std", "kobe-btc?/std", "kobe-evm?/std", "kobe-svm?/std", "kobe-cosmos?/std", "kobe-tron?/std", "kobe-spark?/std", "kobe-fil?/std", "kobe-ton?/std", "kobe-sui?/std", "kobe-nostr?/std", "kobe-xrpl?/std"]
+alloc      = ["kobe-primitives/alloc", "kobe-aptos?/alloc", "kobe-btc?/alloc", "kobe-evm?/alloc", "kobe-svm?/alloc", "kobe-cosmos?/alloc", "kobe-tron?/alloc", "kobe-spark?/alloc", "kobe-fil?/alloc", "kobe-ton?/alloc", "kobe-sui?/alloc", "kobe-nostr?/alloc", "kobe-xrpl?/alloc"]
+rand       = ["kobe-primitives/rand"]
+rand_core  = ["kobe-primitives/rand_core"]
 camouflage = ["kobe-primitives/camouflage"]
-slip10 = ["kobe-primitives/slip10"]
-bip32 = ["kobe-primitives/bip32"]
+slip10     = ["kobe-primitives/slip10"]
+bip32      = ["kobe-primitives/bip32"]
 # Escape hatch: expose `Wallet::seed`. Prefer chain derivers / derive_*.
 raw-seed = ["kobe-primitives/raw-seed"]
 
-btc = ["dep:kobe-btc", "bip32"]
-evm = ["dep:kobe-evm", "bip32"]
-svm = ["dep:kobe-svm", "slip10"]
+btc    = ["dep:kobe-btc", "bip32"]
+evm    = ["dep:kobe-evm", "bip32"]
+svm    = ["dep:kobe-svm", "slip10"]
 cosmos = ["dep:kobe-cosmos", "bip32"]
-tron = ["dep:kobe-tron", "bip32"]
-spark = ["dep:kobe-spark", "bip32"]
-fil = ["dep:kobe-fil", "bip32"]
-ton = ["dep:kobe-ton", "slip10"]
-sui = ["dep:kobe-sui", "slip10"]
-aptos = ["dep:kobe-aptos", "slip10"]
-nostr = ["dep:kobe-nostr", "bip32"]
-xrpl = ["dep:kobe-xrpl", "bip32"]
+tron   = ["dep:kobe-tron", "bip32"]
+spark  = ["dep:kobe-spark", "bip32"]
+fil    = ["dep:kobe-fil", "bip32"]
+ton    = ["dep:kobe-ton", "slip10"]
+sui    = ["dep:kobe-sui", "slip10"]
+aptos  = ["dep:kobe-aptos", "slip10"]
+nostr  = ["dep:kobe-nostr", "bip32"]
+xrpl   = ["dep:kobe-xrpl", "bip32"]
 
 # Preset: the three most requested chains (previous 1.x default).
 mainstream = ["btc", "evm", "svm"]
@@ -45,18 +45,18 @@ all-chains = ["aptos", "btc", "evm", "svm", "cosmos", "tron", "spark", "fil", "t
 
 [dependencies]
 kobe-primitives = { workspace = true, features = ["alloc"] }
-kobe-aptos = { workspace = true, optional = true }
-kobe-btc = { workspace = true, optional = true }
-kobe-evm = { workspace = true, optional = true }
-kobe-svm = { workspace = true, optional = true }
-kobe-cosmos = { workspace = true, optional = true }
-kobe-tron = { workspace = true, optional = true }
-kobe-spark = { workspace = true, optional = true }
-kobe-fil = { workspace = true, optional = true }
-kobe-ton = { workspace = true, optional = true }
-kobe-sui = { workspace = true, optional = true }
-kobe-nostr = { workspace = true, optional = true }
-kobe-xrpl = { workspace = true, optional = true }
+kobe-aptos      = { workspace = true, optional = true }
+kobe-btc        = { workspace = true, optional = true }
+kobe-evm        = { workspace = true, optional = true }
+kobe-svm        = { workspace = true, optional = true }
+kobe-cosmos     = { workspace = true, optional = true }
+kobe-tron       = { workspace = true, optional = true }
+kobe-spark      = { workspace = true, optional = true }
+kobe-fil        = { workspace = true, optional = true }
+kobe-ton        = { workspace = true, optional = true }
+kobe-sui        = { workspace = true, optional = true }
+kobe-nostr      = { workspace = true, optional = true }
+kobe-xrpl       = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/deny.toml
+++ b/deny.toml
@@ -19,7 +19,7 @@ ignore = [
 
 [licenses]
 confidence-threshold = 0.8
-allow = [
+allow                = [
     "MIT",
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
@@ -37,12 +37,12 @@ allow = [
 ignore = false
 
 [bans]
-multiple-versions = "warn"
-wildcards = "deny"
-highlight = "all"
+multiple-versions          = "warn"
+wildcards                  = "deny"
+highlight                  = "all"
 workspace-default-features = "allow"
-external-default-features = "allow"
-allow-workspace = true
+external-default-features  = "allow"
+allow-workspace            = true
 
 # Full `bitcoin` stack is banned: kobe-btc implements address/WIF locally
 # and derives via kobe-primitives. `bitcoin_hashes` remains only as a
@@ -62,6 +62,6 @@ skip = [
 
 [sources]
 unknown-registry = "deny"
-unknown-git = "deny"
-allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+unknown-git      = "deny"
+allow-registry   = ["https://github.com/rust-lang/crates.io-index"]
+allow-git        = []

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel    = "stable"
 components = ["rustfmt", "clippy"]
-profile = "minimal"
+profile    = "minimal"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,18 +1,18 @@
 edition = "2024"
 
 # Line width and formatting
-max_width = 100
+max_width            = 100
 use_small_heuristics = "Default"
 
 # Import organization (stable)
 reorder_imports = true
 reorder_modules = true
-group_imports = "StdExternalCrate"  # nightly-only; enforce manually: std → external → crate
+group_imports   = "StdExternalCrate"  # nightly-only; enforce manually: std → external → crate
 
 # Code style
-newline_style = "Auto"
+newline_style            = "Auto"
 use_field_init_shorthand = true
-use_try_shorthand = true
+use_try_shorthand        = true
 
 # Function formatting
 fn_params_layout = "Tall"


### PR DESCRIPTION
## Summary

Format-only cleanup so workspace TOML reads as a clean table:

- Root `Cargo.toml` (workspace deps, profiles, lints)
- All `crates/*/Cargo.toml`
- `deny.toml`, `clippy.toml`, `rustfmt.toml`, `rust-toolchain.toml`

Keys are padded so `=` columns align; no version pins, features, or lint levels changed. Verified with `tomllib` semantic equality and `cargo check --workspace --all-features`.

## Test plan

- [x] `cargo metadata --no-deps`
- [x] `cargo check --workspace --all-features`
- [x] Diff is whitespace-only in intent (+439 / −439)