### PR TITLE
fix(cli): secret hygiene, stdin mnemonics, stronger smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this workspace are documented in this file. The format is
 
 ## [Unreleased]
 
+### Security
+
+- CLI `kobe mnemonic encrypt/decrypt` respects global `-r` / `--reveal` (phrases
+  hidden by default, same policy as HD wallet output).
+- Mnemonic prefix-expansion errors no longer echo the rejected token (avoids
+  leaking partial secret material via stderr / JSON errors).
+
+### Added
+
+- Import and camouflage accept `-m -` / `-c -` to read a phrase from stdin
+  (reduces shell-history exposure versus argv secrets).
+
+### Changed
+
+- `just all` / `make all` now run the full workspace test suite.
+- Cross-chain smoke tests assert golden abandon@0 addresses for BTC, EVM, SVM,
+  Cosmos, Tron, Spark, FIL, TON, Sui, Aptos, and XRPL.
+
 ## [3.1.0] - 2026-08-08
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ cargo install just cargo-deny
 git clone https://github.com/qntx/kobe.git
 cd kobe
 
-just all    # fmt + clippy-fix + no_std checks + cargo deny
+just all    # fmt + clippy-fix + no_std + cargo deny + tests
 just test   # cargo test --workspace --all-features
 ```
 
@@ -48,7 +48,7 @@ Useful recipes (see `just --list`):
 
 | Recipe | Purpose |
 | --- | --- |
-| `just all` | Default quality gate before a PR |
+| `just all` | Default quality gate before a PR (includes tests) |
 | `just test` | Full workspace tests |
 | `just check-no-std` | Host-side no_std feature matrix (CI also builds `thumbv7m-none-eabi`) |
 | `just deny` | `cargo deny check` |
@@ -160,7 +160,10 @@ All chains surface `kobe_primitives::DeriveError` only (`Path`, `Crypto`,
 
 ## CLI notes
 
-- Global flags: `--json`, `-r` / `--reveal` (secrets hidden by default).
+- Global flags: `--json`, `-r` / `--reveal` (secrets hidden by default for HD
+  and camouflage output).
+- Prefer `-m -` / `-c -` to read mnemonics from stdin rather than argv on shared
+  hosts (shell history / process listings).
 - Self-upgrade for installs from `https://sh.qntx.fun/kobe`:
 
   ```bash
@@ -177,7 +180,7 @@ All chains surface `kobe_primitives::DeriveError` only (`Path`, `Crypto`,
 Maintainers only.
 
 1. CI green on `main` (`lint`, `test`, `deny`, `no_std`).
-2. Local: `just all` and `just test`.
+2. Local: `just all` (includes tests).
 3. Move `[Unreleased]` notes in `CHANGELOG.md` into a dated version section;
    no leftover **Breaking** bullets that belong in the release.
 4. Bump workspace `version` and path dependency major/minor strings in root

--- a/Justfile
+++ b/Justfile
@@ -5,8 +5,8 @@
 # Use `just list` to print recipes instead of running them.
 default: all
 
-# Run the most common checks
-all: fmt clippy-fix check-no-std deny
+# Run the most common checks (includes tests; mirrors CI coverage locally).
+all: fmt clippy-fix check-no-std deny test
 
 # List available recipes
 list:

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 
 .PHONY: all build check check-no-std run test bench clippy clippy-fix fmt doc update deny list
 
-# Default: run the standard local check suite.
-all: fmt clippy-fix check-no-std deny
+# Default: run the standard local check suite (includes tests; mirrors CI).
+all: fmt clippy-fix check-no-std deny test
 
 # List targets (parity with `just list`)
 list:

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ kobe --json -r evm new                   # include them in JSON as well
 kobe upgrade                             # install latest if newer (`update` is an alias)
 kobe upgrade --check                     # report only
 kobe upgrade --force                     # reinstall even when up to date
+
+# Import without putting the mnemonic in argv (preferred on shared hosts)
+echo "abandon abandon ... about" | kobe -r evm import -m -
 ```
 
 Every chain subcommand accepts the shared flags `-w/--words`, `-c/--count`, `-p/--passphrase`, and `--qr` through a flattened `SimpleArgs` group, so ergonomics stay consistent across the 12 networks. Global `-r` / `--reveal` opts into printing mnemonics and private keys (default: hidden).

--- a/crates/kobe-cli/src/commands/mnemonic.rs
+++ b/crates/kobe-cli/src/commands/mnemonic.rs
@@ -1,5 +1,7 @@
 //! Mnemonic utility CLI commands (camouflage encrypt/decrypt).
 
+use std::io::{self, BufRead};
+
 use clap::{Args, Subcommand};
 
 use crate::output::{self, CamouflageOutput};
@@ -20,8 +22,11 @@ enum MnemonicSubcommand {
     /// The output looks like a normal mnemonic and can even generate a
     /// real (empty) wallet. Only someone with the password can recover
     /// the original mnemonic.
+    ///
+    /// Pass `-m -` to read the mnemonic from stdin (avoids shell history).
+    /// Phrases are hidden unless global `-r` / `--reveal` is set.
     Encrypt {
-        /// BIP39 mnemonic phrase to camouflage.
+        /// BIP39 mnemonic phrase (`-` = read one line from stdin).
         #[arg(short, long)]
         mnemonic: String,
 
@@ -33,8 +38,11 @@ enum MnemonicSubcommand {
     /// Decrypt a camouflaged mnemonic back to the original.
     ///
     /// Requires the same password that was used during encryption.
+    ///
+    /// Pass `-c -` to read the camouflaged phrase from stdin.
+    /// Phrases are hidden unless global `-r` / `--reveal` is set.
     Decrypt {
-        /// Camouflaged BIP-39 mnemonic phrase.
+        /// Camouflaged BIP-39 mnemonic phrase (`-` = read one line from stdin).
         #[arg(short = 'c', long)]
         camouflaged: String,
 
@@ -46,34 +54,63 @@ enum MnemonicSubcommand {
 
 impl MnemonicCommand {
     /// Execute the mnemonic command.
-    pub(crate) fn execute(self, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if expansion, camouflage crypto, or I/O fails.
+    pub(crate) fn execute(
+        self,
+        json: bool,
+        reveal: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         match self.command {
             MnemonicSubcommand::Encrypt { mnemonic, password } => {
-                let expanded = kobe::mnemonic::expand(&mnemonic)?;
+                let phrase = read_phrase_arg(&mnemonic, "mnemonic")?;
+                let expanded = kobe::mnemonic::expand(&phrase)?;
                 let camouflaged = kobe::camouflage::encrypt(&expanded, &password)?;
-                let out = CamouflageOutput {
-                    mode: "encrypt",
-                    words: expanded.split_whitespace().count(),
-                    input: expanded,
-                    output: camouflaged.to_string(),
-                };
+                let out = CamouflageOutput::new(
+                    "encrypt",
+                    expanded.split_whitespace().count(),
+                    expanded,
+                    camouflaged.to_string(),
+                    reveal,
+                );
                 output::render_camouflage(&out, json)?;
             }
             MnemonicSubcommand::Decrypt {
                 camouflaged,
                 password,
             } => {
-                let expanded = kobe::mnemonic::expand(&camouflaged)?;
+                let phrase = read_phrase_arg(&camouflaged, "camouflaged mnemonic")?;
+                let expanded = kobe::mnemonic::expand(&phrase)?;
                 let original = kobe::camouflage::decrypt(&expanded, &password)?;
-                let out = CamouflageOutput {
-                    mode: "decrypt",
-                    words: expanded.split_whitespace().count(),
-                    input: expanded.clone(),
-                    output: original.to_string(),
-                };
+                let out = CamouflageOutput::new(
+                    "decrypt",
+                    expanded.split_whitespace().count(),
+                    expanded,
+                    original.to_string(),
+                    reveal,
+                );
                 output::render_camouflage(&out, json)?;
             }
         }
         Ok(())
     }
+}
+
+/// Resolve a phrase argument: literal string, or one stdin line when `-`.
+fn read_phrase_arg(value: &str, label: &str) -> Result<String, Box<dyn std::error::Error>> {
+    if value != "-" {
+        return Ok(value.to_owned());
+    }
+    let mut line = String::new();
+    let n = io::stdin().lock().read_line(&mut line)?;
+    if n == 0 {
+        return Err(format!("expected {label} on stdin, got EOF").into());
+    }
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return Err(format!("expected non-empty {label} on stdin").into());
+    }
+    Ok(trimmed.to_owned())
 }

--- a/crates/kobe-cli/src/commands/simple.rs
+++ b/crates/kobe-cli/src/commands/simple.rs
@@ -5,6 +5,8 @@
 //! surface. This module provides a single generic subcommand reused by each
 //! chain's thin wrapper, eliminating hundreds of lines of boilerplate.
 
+use std::io::{self, BufRead};
+
 use clap::{Args, Subcommand};
 use kobe::{DerivedAccount, Wallet};
 
@@ -50,7 +52,8 @@ impl SimpleArgs {
         match mnemonic {
             None => Ok(Wallet::generate(self.words, self.passphrase.as_deref())?),
             Some(phrase) => {
-                let expanded = kobe::mnemonic::expand(phrase)?;
+                let phrase = resolve_mnemonic_input(phrase)?;
+                let expanded = kobe::mnemonic::expand(&phrase)?;
                 Ok(Wallet::from_mnemonic(
                     &expanded,
                     self.passphrase.as_deref(),
@@ -58,6 +61,26 @@ impl SimpleArgs {
             }
         }
     }
+}
+
+/// Literal mnemonic, or one line from stdin when `value` is `-`.
+///
+/// Prefer `echo '…' | kobe … import -m -` over putting secrets in argv on
+/// shared hosts (shell history / process listings).
+fn resolve_mnemonic_input(value: &str) -> CliResult<String> {
+    if value != "-" {
+        return Ok(value.to_owned());
+    }
+    let mut line = String::new();
+    let n = io::stdin().lock().read_line(&mut line)?;
+    if n == 0 {
+        return Err("expected mnemonic on stdin, got EOF".into());
+    }
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return Err("expected non-empty mnemonic on stdin".into());
+    }
+    Ok(trimmed.to_owned())
 }
 
 /// Subcommand template reused across all simple chain commands.
@@ -70,7 +93,9 @@ pub(crate) enum SimpleSubcommand {
     },
     /// Import wallet from mnemonic phrase.
     Import {
-        /// BIP-39 mnemonic phrase (supports 4-letter prefix expansion).
+        /// BIP-39 mnemonic (`-` = read one line from stdin; avoids shell history).
+        ///
+        /// Supports 4-letter prefix expansion. Prefer stdin on shared hosts.
         #[arg(short, long)]
         mnemonic: String,
 

--- a/crates/kobe-cli/src/main.rs
+++ b/crates/kobe-cli/src/main.rs
@@ -48,7 +48,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Commands::Sui(cmd) => cmd.execute(json, reveal)?,
         Commands::Xrpl(cmd) => cmd.execute(json, reveal)?,
         Commands::Nostr(cmd) => cmd.execute(json, reveal)?,
-        Commands::Mnemonic(cmd) => cmd.execute(json)?,
+        Commands::Mnemonic(cmd) => cmd.execute(json, reveal)?,
         Commands::Upgrade(cmd) => cmd.execute(json)?,
     }
     Ok(())

--- a/crates/kobe-cli/src/output.rs
+++ b/crates/kobe-cli/src/output.rs
@@ -59,9 +59,26 @@ pub struct CamouflageOutput {
     /// Mnemonic word count.
     pub words: usize,
     /// Input mnemonic (original for encrypt, camouflaged for decrypt).
-    pub input: String,
+    /// Present only when `--reveal` was used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<String>,
     /// Output mnemonic (camouflaged for encrypt, recovered for decrypt).
-    pub output: String,
+    /// Present only when `--reveal` was used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output: Option<String>,
+}
+
+impl CamouflageOutput {
+    /// Build camouflage output, redacting phrases unless `reveal` is true.
+    #[must_use]
+    pub fn new(mode: &'static str, words: usize, input: String, output: String, reveal: bool) -> Self {
+        Self {
+            mode,
+            words,
+            input: reveal.then_some(input),
+            output: reveal.then_some(output),
+        }
+    }
 }
 
 impl HdWalletOutput {
@@ -244,12 +261,20 @@ pub fn render_camouflage(
     println!();
     println!("      {}         {}", "Mode".cyan().bold(), mode_label);
     println!("      {}        {} words", "Words".cyan().bold(), out.words);
-    if out.mode == "encrypt" {
-        println!("      {}     {}", in_label.cyan().bold(), out.input);
-        println!("      {}  {}", out_label.cyan().bold(), out.output.green());
-    } else {
-        println!("      {}  {}", in_label.cyan().bold(), out.input);
-        println!("      {}    {}", out_label.cyan().bold(), out.output.green());
+    let hidden = "(hidden; pass -r / --reveal)";
+    match (&out.input, &out.output) {
+        (Some(input), Some(output)) if out.mode == "encrypt" => {
+            println!("      {}     {}", in_label.cyan().bold(), input);
+            println!("      {}  {}", out_label.cyan().bold(), output.green());
+        }
+        (Some(input), Some(output)) => {
+            println!("      {}  {}", in_label.cyan().bold(), input);
+            println!("      {}    {}", out_label.cyan().bold(), output.green());
+        }
+        _ => {
+            println!("      {}     {}", in_label.cyan().bold(), hidden.dimmed());
+            println!("      {}  {}", out_label.cyan().bold(), hidden.dimmed());
+        }
     }
     println!();
     Ok(())

--- a/crates/kobe-cli/src/output.rs
+++ b/crates/kobe-cli/src/output.rs
@@ -71,7 +71,13 @@ pub struct CamouflageOutput {
 impl CamouflageOutput {
     /// Build camouflage output, redacting phrases unless `reveal` is true.
     #[must_use]
-    pub fn new(mode: &'static str, words: usize, input: String, output: String, reveal: bool) -> Self {
+    pub fn new(
+        mode: &'static str,
+        words: usize,
+        input: String,
+        output: String,
+        reveal: bool,
+    ) -> Self {
         Self {
             mode,
             words,

--- a/crates/kobe-primitives/src/mnemonic.rs
+++ b/crates/kobe-primitives/src/mnemonic.rs
@@ -83,16 +83,18 @@ pub fn expand_in(language: Language, phrase: &str) -> Result<String, DeriveError
 fn resolve_token<'a>(word_list: &'a [&'a str; 2048], token: &str) -> Result<&'a str, DeriveError> {
     // Fast path: exact match via binary search (wordlist is sorted).
     if let Ok(idx) = word_list.binary_search(&token) {
-        return word_list
-            .get(idx)
-            .copied()
-            .ok_or_else(|| DeriveError::Input(alloc::format!("mnemonic: unknown word '{token}'")));
+        return word_list.get(idx).copied().ok_or_else(|| {
+            // Should be unreachable: binary_search Ok implies a valid index.
+            DeriveError::Input(String::from("mnemonic: internal wordlist lookup failed"))
+        });
     }
 
     // Token is not an exact word — treat as prefix.
+    // Error messages deliberately omit the raw token so CLI stderr / JSON
+    // errors do not re-echo partial secret material from failed imports.
     if token.len() < MIN_PREFIX_LEN {
         return Err(DeriveError::Input(alloc::format!(
-            "mnemonic: prefix '{token}' is too short (minimum {MIN_PREFIX_LEN} characters)"
+            "mnemonic: word prefix is too short (minimum {MIN_PREFIX_LEN} characters)"
         )));
     }
 
@@ -107,13 +109,13 @@ fn resolve_token<'a>(word_list: &'a [&'a str; 2048], token: &str) -> Result<&'a 
         .collect();
 
     match matches.as_slice() {
-        [] => Err(DeriveError::Input(alloc::format!(
-            "mnemonic: prefix '{token}' does not match any BIP-39 word"
+        [] => Err(DeriveError::Input(String::from(
+            "mnemonic: word prefix does not match any BIP-39 word",
         ))),
         [only] => Ok(*only),
         many => Err(DeriveError::Input(alloc::format!(
-            "mnemonic: prefix '{token}' is ambiguous, matches: {}",
-            many.join(", ")
+            "mnemonic: word prefix is ambiguous (matches {} BIP-39 words)",
+            many.len()
         ))),
     }
 }
@@ -162,6 +164,10 @@ mod tests {
             unreachable!("expected Input error, got {err:?}");
         };
         assert!(msg.contains("too short"), "unexpected message: {msg}");
+        assert!(
+            !msg.contains("aba"),
+            "error must not echo rejected token: {msg}"
+        );
     }
 
     #[test]
@@ -172,6 +178,10 @@ mod tests {
             unreachable!("expected Input error, got {err:?}");
         };
         assert!(msg.contains("does not match"), "unexpected message: {msg}");
+        assert!(
+            !msg.contains("zzzz"),
+            "error must not echo rejected token: {msg}"
+        );
     }
 
     #[test]

--- a/crates/kobe/tests/cross_chain_smoke.rs
+++ b/crates/kobe/tests/cross_chain_smoke.rs
@@ -40,15 +40,16 @@ mod smoke {
     fn evm() {
         let w = wallet();
         let a = kobe::evm::Deriver::new(&w).derive(0).unwrap();
-        assert!(a.address().starts_with("0x"));
-        assert_eq!(a.address().len(), 42);
+        // Cross-checked in kobe-evm KAT (iancoleman / MetaMask Standard path).
+        assert_eq!(a.address(), "0x9858EfFD232B4033E47d90003D41EC34EcaEda94");
     }
 
     #[test]
     fn svm() {
         let w = wallet();
         let a = kobe::svm::Deriver::new(&w).derive(0).unwrap();
-        assert!(!a.address().is_empty());
+        // Phantom Standard path KAT in kobe-svm.
+        assert_eq!(a.address(), "HAgk14JpMQLgt6rVgv7cBQFJWFto5Dqxi472uT3DKpqk");
         assert!(!a.keypair_base58().is_empty());
     }
 
@@ -56,54 +57,69 @@ mod smoke {
     fn cosmos() {
         let w = wallet();
         let a = kobe::cosmos::Deriver::new(&w).derive(0).unwrap();
-        assert!(a.address().starts_with("cosmos1"));
+        assert_eq!(a.address(), "cosmos19rl4cm2hmr8afy4kldpxz3fka4jguq0auqdal4");
     }
 
     #[test]
     fn tron() {
         let w = wallet();
         let a = kobe::tron::Deriver::new(&w).derive(0).unwrap();
-        assert!(a.address().starts_with('T'));
+        assert_eq!(a.address(), "TUEZSdKsoDHQMeZwihtdoBiN46zxhGWYdH");
     }
 
     #[test]
     fn spark() {
         let w = wallet();
         let a = kobe::spark::Deriver::new(&w).derive(0).unwrap();
-        assert!(a.address().starts_with("spark"));
+        assert_eq!(
+            a.address(),
+            "spark1pgssy6vty7krpze82ecm8j39gd35v35aqjjmhftc4culawsavkyh564uc6zmqs"
+        );
     }
 
     #[test]
     fn fil() {
         let w = wallet();
         let a = kobe::fil::Deriver::new(&w).derive(0).unwrap();
-        assert!(a.address().starts_with("f1"));
+        assert_eq!(a.address(), "f1qode47ievxlxzk6z2viuovedabmn3tq6t57uqhq");
     }
 
     #[test]
     fn ton() {
         let w = wallet();
         let a = kobe::ton::Deriver::new(&w).derive(0).unwrap();
-        assert!(a.address().starts_with('U') || a.address().starts_with('E'));
+        // Default: mainnet, non-bounceable, workchain 0.
+        assert_eq!(
+            a.address(),
+            "UQBHyu-oZVDHRYQ1-rKlGqpHy5yAqanPBirEQNMNOmfHLtaT"
+        );
     }
 
     #[test]
     fn sui() {
         let w = wallet();
         let a = kobe::sui::Deriver::new(&w).derive(0).unwrap();
-        assert!(a.address().starts_with("0x"));
+        assert_eq!(
+            a.address(),
+            "0x5e93a736d04fbb25737aa40bee40171ef79f65fae833749e3c089fe7cc2161f1"
+        );
     }
 
     #[test]
     fn aptos() {
         let w = wallet();
         let a = kobe::aptos::Deriver::new(&w).derive(0).unwrap();
-        assert!(a.address().starts_with("0x"));
+        assert_eq!(
+            a.address(),
+            "0xeb663b681209e7087d681c5d3eed12aaa8e1915e7c87794542c3f96e94b3d3bf"
+        );
     }
 
     #[test]
     fn nostr() {
         let w = wallet();
+        // NIP-06 abandon vectors differ; smoke only checks encoding shape here
+        // when using the shared abandon mnemonic (not NIP official TV mnemonics).
         let a = kobe::nostr::Deriver::new(&w).derive(0).unwrap();
         assert!(a.npub().starts_with("npub1"));
         assert!(a.nsec().starts_with("nsec1"));
@@ -113,7 +129,7 @@ mod smoke {
     fn xrpl() {
         let w = wallet();
         let a = kobe::xrpl::Deriver::new(&w).derive(0).unwrap();
-        assert!(a.address().starts_with('r'));
+        assert_eq!(a.address(), "rHsMGQEkVNJmpGWs8XUBoTBiAAbwxZN5v3");
     }
 
     #[test]

--- a/skills/kobe/SKILL.md
+++ b/skills/kobe/SKILL.md
@@ -309,15 +309,17 @@ kobe --json nostr new
 
 ### Mnemonic Camouflage
 
+Phrases are **hidden unless** `-r` / `--reveal`. Prefer stdin for the phrase:
+
 ```bash
-# Encrypt a real mnemonic into a valid-looking decoy
-kobe mnemonic encrypt -m "real phrase here ..." -p "strong-password"
+# Encrypt (output hidden without -r)
+echo "real phrase here ..." | kobe mnemonic encrypt -m - -p "strong-password" -r
 
-# Recover the original from the decoy
-kobe mnemonic decrypt -c "decoy phrase here ..." -p "strong-password"
+# Recover
+echo "decoy phrase here ..." | kobe mnemonic decrypt -c - -p "strong-password" -r
 
-# JSON output
-kobe --json mnemonic encrypt -m "real phrase ..." -p "secret"
+# JSON with secrets
+echo "real phrase ..." | kobe --json -r mnemonic encrypt -m - -p "secret"
 ```
 
 ## JSON Output Schemas
@@ -363,6 +365,8 @@ For EVM/SVM: `network` and `address_type` are omitted; `derivation_style` is inc
 
 ### Camouflage (`encrypt` / `decrypt`)
 
+With `-r` / `--reveal`:
+
 ```json
 {
   "mode": "encrypt",
@@ -371,6 +375,8 @@ For EVM/SVM: `network` and `address_type` are omitted; `derivation_style` is inc
   "output": "camouflaged phrase ..."
 }
 ```
+
+Without `--reveal`, `input` and `output` are omitted.
 
 ### Error
 


### PR DESCRIPTION
## Summary

Audit remediation (CLI secrets + verification):

### Security
- **`kobe mnemonic encrypt/decrypt`** respects global **`-r` / `--reveal`** (phrases hidden by default, same as HD output).
- **Mnemonic prefix expand** errors no longer echo the rejected token (stderr / JSON `error` safe).
- **`-m -` / `-c -`**: read phrase from **stdin** for import and camouflage (less shell-history exposure).

### Verification
- **`just all` / `make all`** now include the full workspace **test** suite.
- **`cross_chain_smoke`**: golden abandon@0 addresses for BTC, EVM, SVM, Cosmos, Tron, Spark, FIL, TON, Sui, Aptos, XRPL.

### Docs
- CHANGELOG Unreleased, CONTRIBUTING, README, skills/kobe.

## Test plan

- [x] `cargo test --workspace --all-features`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Camouflage without `-r` → hidden; with `-r --json` → phrases present
- [x] `echo mnemonic | kobe evm import -m - --json` → expected ETH address
- [x] `kobe evm import -m zzzz` → error without token `zzzz`