### PR TITLE
release: bump crate version to 3.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "kobe"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "kobe-aptos",
  "kobe-btc",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-aptos"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "hex",
  "kobe-primitives",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-btc"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "bech32",
  "bs58",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-cli"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "clap",
  "colored",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-cosmos"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "bech32",
  "kobe-primitives",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-evm"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "alloy-primitives",
  "kobe-primitives",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-fil"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "blake2",
  "kobe-primitives",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-nostr"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "bech32",
  "kobe-primitives",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-primitives"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "bip32",
  "bip39",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-spark"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "bech32",
  "hex",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-sui"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "blake2",
  "hex",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-svm"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "bs58",
  "kobe-primitives",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-ton"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "base64",
  "kobe-primitives",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-tron"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "bs58",
  "kobe-primitives",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-xrpl"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "bs58",
  "kobe-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude         = ["fuzz"]
 resolver        = "3"
 
 [workspace.package]
-version      = "3.1.0"
+version      = "3.1.1"
 edition      = "2024"
 # Minimum supported Rust version. `edition = "2024"` was stabilized in 1.85;
 # we pin to 1.85 here and enforce it in CI. Bumping this is a breaking change.


### PR DESCRIPTION
Completes v3.1.1: #45 merged CHANGELOG but missed Cargo.toml/Cargo.lock version bump.