### PR TITLE
feat: from_mnemonic_expanded + library feature docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,15 +97,23 @@ Every chain subcommand accepts the shared flags `-w/--words`, `-c/--count`, `-p/
 
 ### Library Usage
 
+```toml
+# Default is `std` only — enable chains (or `mainstream` / `all-chains`) explicitly.
+kobe = { version = "3.2", features = ["std", "mainstream"] }
+# Optional: `rand` for Wallet::generate; chain features: evm, btc, svm, …
+```
+
 ```rust
 use kobe::prelude::*;     // Wallet, Derive, DeriveExt, DerivationStyle trait, ...
-use kobe::evm::Deriver;   // or kobe::btc, kobe::svm, kobe::cosmos, ...
+use kobe::evm::Deriver;   // requires feature "evm" (or "mainstream")
 
-// Import from mnemonic
+// Import from mnemonic (full BIP-39 words)
 let wallet = Wallet::from_mnemonic(
     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
     None,  // optional passphrase
 )?;
+// Abbreviated 4-letter English prefixes (same as CLI import):
+// let wallet = Wallet::from_mnemonic_expanded("aban aban … abou", None)?;
 
 // Derive addresses (accessor methods — fields are private for zeroization safety)
 let eth = kobe::evm::Deriver::new(&wallet).derive(0)?;

--- a/crates/README.md
+++ b/crates/README.md
@@ -50,14 +50,15 @@ The umbrella `kobe` crate provides fine-grained feature control:
 
 | Feature | Default | Description |
 | --- | --- | --- |
-| `std` | ✅ | Enable `std` support |
-| `alloc` | ✅ | Enable `alloc` (implied by `std`) |
+| `std` | ✅ | Enable `std` support (default = `["std"]` only) |
+| `alloc` | | Enable `alloc` (implied by `std`) |
 | `rand` | | Enable random mnemonic generation |
 | `camouflage` | | Enable mnemonic camouflage encryption |
 | `raw-seed` | | Expose `Wallet::seed` (escape hatch; prefer derivers) |
+| `mainstream` | | Preset: `btc` + `evm` + `svm` |
 | `btc` | | Bitcoin chain support (enables `bip32`) |
 | `evm` | | Ethereum chain support (enables `bip32`) |
-| `svm` | ✅ | Solana chain support (enables `slip10`) |
+| `svm` | | Solana chain support (enables `slip10`) |
 | `cosmos` | | Cosmos chain support (enables `bip32`) |
 | `tron` | | Tron chain support (enables `bip32`) |
 | `spark` | | Spark chain support (enables `bip32`) |

--- a/crates/kobe-cli/src/commands/simple.rs
+++ b/crates/kobe-cli/src/commands/simple.rs
@@ -53,9 +53,8 @@ impl SimpleArgs {
             None => Ok(Wallet::generate(self.words, self.passphrase.as_deref())?),
             Some(phrase) => {
                 let phrase = resolve_mnemonic_input(phrase)?;
-                let expanded = kobe::mnemonic::expand(&phrase)?;
-                Ok(Wallet::from_mnemonic(
-                    &expanded,
+                Ok(Wallet::from_mnemonic_expanded(
+                    &phrase,
                     self.passphrase.as_deref(),
                 )?)
             }

--- a/crates/kobe-primitives/src/wallet.rs
+++ b/crates/kobe-primitives/src/wallet.rs
@@ -201,6 +201,21 @@ impl Wallet {
         Ok(Self::from_parts(&mnemonic, language, passphrase))
     }
 
+    /// Expand 4-letter BIP-39 English prefixes then import (same path as CLI `import`).
+    ///
+    /// Full words pass through [`mnemonic::expand`](crate::mnemonic::expand) unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if expansion or BIP-39 parse fails.
+    pub fn from_mnemonic_expanded(
+        phrase: &str,
+        passphrase: Option<&str>,
+    ) -> Result<Self, DeriveError> {
+        let expanded = crate::mnemonic::expand(phrase)?;
+        Self::from_mnemonic(&expanded, passphrase)
+    }
+
     /// Create a wallet from an existing mnemonic phrase in the specified language.
     ///
     /// # Arguments


### PR DESCRIPTION
## Summary

Companion DX for the signer 3.0 optimal-slice work:

- Add `Wallet::from_mnemonic_expanded` (4-letter BIP-39 English prefixes).
- CLI `import` / `build_wallet` uses that single library path.
- README library examples require explicit `features` (`mainstream` / chains).
- Fix `crates/README` feature table (default is `std` only; remove incorrect svm default mark).

## Test plan

- [x] `cargo check -p kobe-cli`
- [x] `cargo test -p kobe-primitives --lib from_mnemonic`
- [ ] CI green