### PR TITLE
feat(arweave): ECDSA-only HD derivation (coin 472)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,8 @@ jobs:
         run: cargo check -p kobe-xrpl --target thumbv7m-none-eabi --no-default-features --features alloc
       - name: kobe-casper (no_std)
         run: cargo check -p kobe-casper --target thumbv7m-none-eabi --no-default-features --features alloc
+      - name: kobe-arweave (no_std)
+        run: cargo check -p kobe-arweave --target thumbv7m-none-eabi --no-default-features --features alloc
       - name: kobe (no_std)
         run: cargo check -p kobe --target thumbv7m-none-eabi --no-default-features --features alloc
       - name: kobe (no_std + all chains)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,6 @@ jobs:
   publish:
     uses: qntx/workflows/.github/workflows/publish-crates.yml@main
     with:
-      packages: "kobe-primitives kobe-aptos kobe-btc kobe-evm kobe-svm kobe-cosmos kobe-tron kobe-spark kobe-fil kobe-ton kobe-sui kobe-xrpl kobe-nostr kobe-casper kobe kobe-cli"
+      packages: "kobe-primitives kobe-aptos kobe-arweave kobe-btc kobe-casper kobe-cosmos kobe-evm kobe-fil kobe-nostr kobe-spark kobe-sui kobe-svm kobe-ton kobe-tron kobe-xrpl kobe kobe-cli"
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this workspace are documented in this file. The format is
 
 ## [Unreleased]
 
+## [3.4.0] - 2026-08-12
+
+### Added
+
+- **Arweave ECDSA (`kobe-arweave`)** — offline HD derivation (SLIP-44 coin type
+  `472`), secp256k1 only:
+  - Path `m/44'/472'/0'/0/{i}`
+  - Address: Base64URL(SHA-256(**compressed** 33-byte public key)) — matches
+    protocol `ar_wallet` / arweave-js `master-ec` identifier hash
+  - Helpers: `address_from_compressed_pubkey`, `owner_from_compressed_pubkey`
+    (recovered owner encoding when tx `owner` is empty)
+  - CLI: `kobe arweave` / `kobe ar` (`new` / `import`)
+  - Umbrella feature: `arweave` (included in `all-chains`; not in `mainstream`)
+  - Explicit non-goals: RSA-PSS wallets, transaction signing (future
+    `signer-arweave`)
+- Rewritten [`CONTRIBUTING.md`](CONTRIBUTING.md): full chain registration
+  matrix (umbrella, CLI, CI no_std, crates.io publish order, docs, KATs).
+
+### Fixed
+
+- CI `no_std` job and crates.io publish order include `kobe-arweave`.
+
 ## [3.3.0] - 2026-08-09
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,91 +1,102 @@
 # Contributing to Kobe
 
-Thank you for improving Kobe. This document is the single source of truth for
-how to develop, extend, and release the workspace. Please read it before
-opening a pull request.
+Normative process for developing, extending, reviewing, and releasing Kobe.
+Prefer this document over tribal knowledge. Incomplete chain wiring has been a
+recurring defect; the [New chain registration matrix](#new-chain-registration-matrix)
+lists every required touchpoint, including CI and crates.io publish order.
 
-## Code of collaboration
+Agents: also read [`AGENTS.md`](AGENTS.md) for architecture rules. Process and
+checklists live **here**.
 
-- Prefer **small, reviewable PRs** with a clear problem statement.
-- Match existing style: workspace Clippy lints (`pedantic` + `nursery`),
-  `rustfmt` with the project config, explicit error handling.
-- Do **not** invent APIs. Follow the [chain API contract](#chain-api-contract).
-- Do **not** reintroduce the full `bitcoin` crate (`deny.toml` bans it).
-- Secrets (mnemonics, private keys, WIF, `nsec`, Solana keypairs) must stay in
-  `Zeroizing` and use **redacted `Debug`**. Never `#[derive(Debug)]` on types
-  that hold secret material (`Zeroizing` itself does not redact).
-- Every chain derivation path must be pinned with **cross-implementation KATs**
-  (not self-confirming dumps).
+---
 
-By contributing, you agree that your contributions are dual-licensed under the
-project’s [MIT](LICENSE-MIT) OR [Apache-2.0](LICENSE-APACHE) terms (see
-`README.md`).
+## Principles
+
+| Rule | Meaning |
+| --- | --- |
+| Small PRs | One problem per PR; reviewable diffs. |
+| No invented APIs | Follow the [chain API contract](#chain-api-contract). |
+| No compatibility debt | Remove obsolete paths; do not add dual APIs or migrations “for now.” |
+| No banned stacks | Full `bitcoin` crate is denied (`deny.toml`). Encode addresses/WIF in-tree. |
+| Secrets hygiene | Mnemonics, seeds, private keys, WIF, `nsec`, Solana keypairs: `Zeroizing` + redacted `Debug`. Never `#[derive(Debug)]` on secret-bearing types. |
+| Independent KATs | Every derivation path is pinned to a third-party or protocol vector — not a dump of our own previous output. |
+
+License: contributions are dual-licensed [MIT](LICENSE-MIT) OR
+[Apache-2.0](LICENSE-APACHE) as stated in `README.md`.
+
+---
 
 ## Prerequisites
 
-| Tool | Notes |
+| Tool | Role |
 | --- | --- |
-| Rust | Stable + nightly (fmt/clippy). MSRV is declared in root `Cargo.toml` (`rust-version`). |
-| [`just`](https://github.com/casey/just) | Preferred task runner (`Justfile`; `Makefile` mirrors the same suite). |
-| [`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny) | License / ban / advisory checks. |
+| Rust stable | Build, test, MSRV (`rust-version` in root `Cargo.toml`). |
+| Rust nightly | `rustfmt` import grouping; Clippy workspace lints. |
+| [`just`](https://github.com/casey/just) | Canonical task runner (`Justfile`). `Makefile` mirrors the same suite. |
+| [`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny) | Licenses, bans, advisories, sources. |
 
 ```bash
 rustup toolchain install stable nightly --component rustfmt,clippy
 cargo install just cargo-deny
 ```
 
-## Local development
+---
+
+## Local quality gate
 
 ```bash
 git clone https://github.com/qntx/kobe.git
 cd kobe
-
-just all    # fmt + clippy-fix + no_std + cargo deny + tests
-just test   # cargo test --workspace --all-features
+just all
 ```
 
-Useful recipes (see `just --list`):
+`just all` runs: **fmt → clippy-fix → check-no-std → deny → test**.
 
 | Recipe | Purpose |
 | --- | --- |
-| `just all` | Default quality gate before a PR (includes tests) |
-| `just test` | Full workspace tests |
-| `just check-no-std` | Host-side no_std feature matrix (CI also builds `thumbv7m-none-eabi`) |
+| `just all` | Default pre-PR gate |
+| `just check-no-std` | Host-side no_std matrix (every library crate + umbrella `all-chains`) |
+| `just test` | `cargo test --workspace --all-features` |
 | `just deny` | `cargo deny check` |
-| `just fmt` / `just clippy` | Format and lint |
+| `just fmt` / `just clippy` | Format / lint |
 
-CI (`.github/workflows/ci.yml`) runs format, Clippy `-D warnings`, tests,
-`cargo-deny`, and no_std targets. A PR should be green there.
+CI (`.github/workflows/ci.yml`) also builds bare-metal `thumbv7m-none-eabi` per
+library crate. Host `check-no-std` is necessary but not always sufficient: a
+crate that pulls `std` accidentally may still pass host checks and fail CI.
 
-### Commit and PR hygiene
+When adding a chain, update **both** the local matrix (`Justfile` / `Makefile`)
+and the CI `no-std` job — see the registration matrix below.
 
-- Use imperative commit subjects (`feat(cli): …`, `fix(btc): …`, `docs: …`).
-- Reference issues when applicable.
-- Update [`CHANGELOG.md`](CHANGELOG.md) under `[Unreleased]` for user-visible
-  changes (Keep a Changelog format).
-- Do not force-push shared branches without coordination.
+---
 
-## Project layout
+## Repository layout
 
 ```text
-Cargo.toml              workspace + shared deps / lints
+Cargo.toml                 workspace package versions, shared deps, lints
+deny.toml                  licenses / bans / advisories / sources
+Justfile / Makefile        local gates (keep in sync with each other)
+.github/workflows/
+  ci.yml                   lint, test, deny, no_std (thumbv7m-none-eabi)
+  publish.yml              crates.io publish order
+  release.yml              CLI binary release
 crates/
-  kobe-primitives/      Wallet, Derive, bip32, slip10, encoding, …
-  kobe-<chain>/         one crate per network
-  kobe/                 umbrella re-exports + features
-  kobe-cli/             `kobe` binary
-crates/README.md        crate table, graph, features
-deny.toml               licenses, bans (no full `bitcoin` crate)
+  kobe-primitives/         Wallet, Derive, bip32, slip10, encoding, …
+  kobe-<chain>/            one publishable crate per network
+  kobe/                    umbrella re-exports + feature flags
+  kobe-cli/                `kobe` binary (builds with all-chains)
+  README.md                crate table, graph, feature table
+skills/kobe/SKILL.md       agent-facing CLI contract
+CONTRIBUTING.md            this file
+CHANGELOG.md               Keep a Changelog
 ```
 
-Library crates target `no_std` + `alloc` where possible. Prefer
-`Wallet::derive_secp256k1` / `derive_ed25519` over exposing the raw seed
-(`raw-seed` feature is an escape hatch only).
+Library crates target `no_std` + `alloc`. Prefer
+`Wallet::derive_secp256k1` / `derive_ed25519`. Feature `raw-seed` is an escape
+hatch only.
+
+---
 
 ## Chain API contract
-
-Every `kobe-<chain>` deriver follows the same surface. Prefer this table when
-adding a chain or reviewing API diffs.
 
 ### Construction
 
@@ -93,20 +104,19 @@ adding a chain or reviewing API diffs.
 | --- | --- |
 | `Deriver::new(wallet) -> Self` | Infallible. Optional network/format via args or `with_*`. |
 | `Deriver::new(wallet, network) -> Self` | BTC: network is a required second argument. |
-| `with_config` / `with_network` / `with_format` | Chain-specific configuration; still infallible. |
+| `with_config` / `with_network` / `with_algo` / … | Chain-specific; still infallible constructors. |
 
-Do **not** return `Result` from `new` unless initialization can fail for a
-real reason.
+Do **not** return `Result` from `new` unless initialization can genuinely fail.
 
 ### Derivation
 
 | Method | Contract |
 | --- | --- |
-| `derive(index)` | Default path / style for the chain. |
+| `derive(index)` | Default path / style. |
 | `derive_at(path: &str)` | Arbitrary BIP-32 / SLIP-10 path (inherent). |
-| `Derive::derive_path` | Trait method; must forward to `derive_at`. |
+| `Derive::derive_path` | Trait method; **must** forward to `derive_at`. |
 | `DeriveExt::derive_many(start, count)` | Batch of `derive(index)`. |
-| `derive_with(style_or_type, index)` | Only when the chain has a style / address-type axis. |
+| `derive_with(style_or_type, index)` | Only when the chain has a style / type axis. |
 | `derive_at_with(path, style_or_type)` | Non-standard path + explicit type (BTC). |
 | `derive_structured` | Pre-parsed path object (BTC). |
 
@@ -115,92 +125,190 @@ real reason.
 | Type | When |
 | --- | --- |
 | `DerivedAccount` | Default for most chains. |
-| `BtcAccount` | Extra WIF + address type + path. |
-| `SvmAccount` | Extra keypair base58. |
-| `NostrAccount` | Extra `nsec`. |
+| `BtcAccount` | WIF + address type + path. |
+| `SvmAccount` | 64-byte keypair base58. |
+| `NostrAccount` | `nsec` / `npub`. |
+| `CasperAccount` | AccountHash + algo + tagged pubkey hex. |
 
-All account types implement `AsRef<DerivedAccount>` (and usually `Deref`).
+Account newtypes implement `AsRef<DerivedAccount>` (and usually `Deref`).
 
 ### Key material
 
-| Path | Use |
+| API | Use |
 | --- | --- |
 | `Wallet::derive_secp256k1` / `derive_ed25519` | Preferred inside chain crates. |
-| `Wallet::seed` | **Feature `raw-seed` only** (off by default). |
+| `Wallet::seed` | Feature `raw-seed` only (off by default). |
 
 ### Debug / secrets
 
-| Type | `Debug` contract |
+| Type | `Debug` |
 | --- | --- |
 | `Wallet` | Redacts mnemonic and seed (`[REDACTED]`). |
 | `DerivedAccount` | Redacts private key; path, pubkey, address visible. |
-| `BtcAccount` / `SvmAccount` / `NostrAccount` | Redacts WIF / keypair / `nsec`. |
+| Chain secret newtypes | Redact WIF / keypair / `nsec` / etc. |
 
 ### Errors
 
-All chains surface `kobe_primitives::DeriveError` only (`Path`, `Crypto`,
-`Input`, `AddressEncoding`, `Mnemonic`).
+Surface `kobe_primitives::DeriveError` only (`Path`, `Crypto`, `Input`,
+`AddressEncoding`, `Mnemonic`).
 
 ### Naming
 
-- Inherent method: `derive_at`
-- Trait method: `derive_path` (forwards to `derive_at`)
-- Do not reintroduce `derive_at_path` / `derive_bip32_path`
+| Correct | Forbidden |
+| --- | --- |
+| Inherent `derive_at` | `derive_at_path`, `derive_bip32_path` |
+| Trait `derive_path` → forwards to `derive_at` | Dual public names for the same operation |
 
-## Adding a chain
+---
 
-1. Scaffold `crates/kobe-<name>/` with `no_std` + `alloc`, workspace lints, and
-   `Derive` / `DeriveExt`.
-2. Wire features on the `kobe` umbrella and `kobe-cli` (subcommand + output).
-3. Add KATs against an independent reference implementation.
-4. Extend `crates/kobe/tests/cross_chain_smoke.rs` when appropriate.
-5. Document the path and address format in `README.md` and update
-   `CHANGELOG.md`.
-6. Keep `cargo deny` clean (no banned crates).
+## New chain registration matrix
+
+**Source of truth for “a chain exists”:** directory `crates/kobe-<name>/` with
+package name `kobe-<name>`.
+
+**Feature name** = package name without the `kobe-` prefix
+(`kobe-arweave` → feature `arweave`, re-export `kobe::arweave`).
+
+Complete **every** row before merge. Omitting CI or publish rows has shipped
+broken releases before.
+
+| # | Touchpoint | Required action |
+| --- | --- | --- |
+| 1 | `crates/kobe-<name>/` | Scaffold: `#![cfg_attr(not(feature = "std"), no_std)]`, features `std`/`alloc`, workspace lints, `Derive` + `derive_at`. |
+| 2 | Root `Cargo.toml` | `[workspace.dependencies] kobe-<name> = { version = "<maj.min>", path = "…", default-features = false }`. Bump workspace `version` when releasing. |
+| 3 | `crates/kobe/Cargo.toml` | Optional dep; feature `"name" = ["dep:kobe-<name>", "bip32" \| "slip10"]`; add to `std` / `alloc` lists (`kobe-<name>?/std`); add `"name"` to `all-chains`. Do **not** add to `mainstream` unless product decision says so. |
+| 4 | `crates/kobe/src/lib.rs` | `#[cfg(feature = "name")] pub use kobe_<name> as name;` |
+| 5 | `Justfile` `check-no-std` | `cargo check -p kobe-<name> --no-default-features --features alloc` |
+| 6 | `Makefile` `check-no-std` | Same command as Justfile (keep mirrors identical). |
+| 7 | `.github/workflows/ci.yml` job `no-std` | `cargo check -p kobe-<name> --target thumbv7m-none-eabi --no-default-features --features alloc` |
+| 8 | `.github/workflows/publish.yml` | Insert `kobe-<name>` in `packages` **before** `kobe` and `kobe-cli` (after `kobe-primitives`). Alphabetical among chains is preferred. **If omitted, tag release will not publish the crate.** |
+| 9 | `crates/kobe-cli` | Command module (`new` / `import` or chain-specific flags); clap primary `name = "<name>"` (aliases optional); `Commands` variant; `main.rs` match arm. Module **filename** may differ from feature name (`btc` → `bitcoin.rs`). Implementation must call `kobe::<name>::…`. |
+| 10 | `crates/kobe/tests/cross_chain_smoke.rs` | abandon@0 (or chain-standard) assertion when `all-chains` is enabled. |
+| 11 | KATs in chain crate | Independent reference vectors; document the source in the test comment. Negative test for the most likely wrong encoding (e.g. uncompressed vs compressed pubkey). |
+| 12 | `README.md` | Supported-chains table row; intro / Design chain **count** and name list; Quick Start example if useful. |
+| 13 | `crates/README.md` | Crate table, dependency graph, feature table, badge link anchors. |
+| 14 | `skills/kobe/SKILL.md` | Chain table, aliases, path reference, private-key format, examples; keep chain count accurate. |
+| 15 | `CHANGELOG.md` | User-visible entry under `[Unreleased]` or the release section. |
+| 16 | Protocol accuracy | Cite protocol docs / reference clients in crate docs or KAT comments. |
+
+### Worked example: Arweave ECDSA (`kobe-arweave`)
+
+| Item | Value |
+| --- | --- |
+| Package / feature | `kobe-arweave` / `arweave` |
+| Path | `m/44'/472'/0'/0/{i}` (SLIP-44 coin 472) |
+| Address | `Base64URL_nopad(SHA-256(compressed 33-byte secp256k1 pubkey))` |
+| References | [ECDSA Keys](https://docs.arweave.org/developers/development/overview/ecdsa-keys); node `ar_wallet.erl` (`ECDSA_PUB_KEY_SIZE = 33`); arweave-js `master-ec` |
+| Out of scope | RSA-PSS wallets; transaction signing (companion signer crate) |
+| CLI | `kobe arweave` / alias `ar` |
+
+---
+
+## Implementation guide for a new chain
+
+1. **Protocol spike** — Address algorithm from primary sources (node code,
+   official docs, reference client). Decide BIP-32 vs SLIP-10, coin type,
+   pubkey encoding, hash, address alphabet. Record non-goals.
+2. **Scaffold** — Copy the closest crate (`kobe-xrpl` for secp BIP-44;
+   `kobe-sui` for SLIP-10 Ed25519).
+3. **KAT first** — Lock gold vectors from an independent tool before API polish.
+4. **Wire the matrix** — Rows 2–10, then 12–15. Manually verify CI and
+   `publish.yml` (rows 7–8); they are the most commonly omitted.
+5. **`just all`** — Fix Clippy, fmt, deny, tests.
+6. **PR** — Title `feat(<name>): …`; body links protocol sources and KAT origin.
+
+---
 
 ## CLI notes
 
-- Global flags: `--json`, `-r` / `--reveal` (secrets hidden by default for HD
-  and camouflage output).
-- Prefer `-m -` / `-c -` to read mnemonics from stdin rather than argv on shared
-  hosts (shell history / process listings).
-- Self-upgrade for installs from `https://sh.qntx.fun/kobe`:
+| Topic | Rule |
+| --- | --- |
+| Global flags | `--json`, `-r` / `--reveal` (secrets hidden by default). |
+| Mnemonics on shared hosts | Prefer `-m -` / stdin over argv. |
+| Simple chains | Reuse `SimpleSubcommand` (`new` / `import`). |
+| Complex chains | Dedicated modules (BTC network/type, EVM style, …). |
+| Self-upgrade | `kobe upgrade` (`update` alias) via `sh.qntx.fun`; does not overwrite Cargo installs. |
+| Agent contract | Keep `skills/kobe/SKILL.md` verbs and flags 1:1 with clap. |
 
-  ```bash
-  kobe upgrade              # alias: kobe update
-  kobe upgrade --check
-  ```
+---
 
-  Re-invokes the official installer. Cargo installs under `.cargo/bin` are
-  **not** overwritten; the command prints a `cargo install kobe-cli --force`
-  hint instead.
+## Commit and PR hygiene
+
+- Imperative subjects: `feat(arweave): …`, `fix(btc): …`, `docs: …`, `ci: …`.
+- Update `CHANGELOG.md` for user-visible behavior.
+- Do not force-push shared branches without coordination.
+- Crypto / new-chain PRs must state **protocol sources** and confirm the
+  registration matrix (especially CI no_std + `publish.yml`).
+
+### Reviewer checklist (crypto / new chain)
+
+- [ ] Address algorithm matches cited protocol (not Ethereum-by-accident).
+- [ ] Compressed vs uncompressed (or other encoding axes) explicit and tested.
+- [ ] KATs cite independent source; negative test for the most likely wrong encoding.
+- [ ] Matrix rows 5–8 complete: Justfile, Makefile, CI no_std, **publish.yml**.
+- [ ] Secrets redacted; no `Debug` derive on secret types.
+- [ ] `deny.toml` still clean (no full `bitcoin` crate).
+- [ ] README / skill chain counts match the real set.
+
+---
+
+## Continuous integration
+
+| Job | Workflow | Purpose |
+| --- | --- | --- |
+| `lint` | `ci.yml` | `cargo fmt --check`, Clippy `-D warnings`, all features. |
+| `test` | `ci.yml` | Build + test workspace `--all-features`. |
+| `deny` | `ci.yml` | `cargo-deny-action` with `--all-features`. |
+| `no_std` | `ci.yml` | Per-crate `thumbv7m-none-eabi` + umbrella `all-chains`. |
+| Publish | `publish.yml` on tag `v*.*.*` | Ordered crates.io publish. |
+| Release | `release.yml` on tag | `kobe-cli` binaries. |
+
+Publish package order in `publish.yml`:
+
+```text
+kobe-primitives → every kobe-<chain> → kobe → kobe-cli
+```
+
+A chain missing from this list will never reach crates.io on tag.
+
+---
 
 ## Release process
 
 Maintainers only.
 
-1. CI green on `main` (`lint`, `test`, `deny`, `no_std`).
-2. Local: `just all` (includes tests).
-3. Move `[Unreleased]` notes in `CHANGELOG.md` into a dated version section;
-   no leftover **Breaking** bullets that belong in the release.
-4. Bump workspace `version` and path dependency major/minor strings in root
-   `Cargo.toml` (e.g. `3.1.0` → path `"3.1"`).
-5. Tag and push: `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`.
-6. Confirm GitHub Actions `release.yml` (binaries) and `publish.yml`
-   (crates.io) succeed.
-7. Publish order is handled by the workflow: `kobe-primitives` → chain crates →
-   `kobe` → `kobe-cli`.
+1. `main` green on all CI jobs above.
+2. Local: `just all`.
+3. `CHANGELOG.md`: move `[Unreleased]` into a dated `## [X.Y.Z]` section.
+4. Bump workspace `version` and path dependency version prefixes in root
+   `Cargo.toml` (e.g. `3.4.0` with path deps `"3.4"`).
+5. Tag and push:
 
-Semantic Versioning applies. Document breaking API changes under a major bump.
+   ```bash
+   git tag -a vX.Y.Z -m "vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+6. Confirm `release.yml` (binaries) and `publish.yml` (crates.io) succeed.
+
+Semantic Versioning: breaking public API → major; new chain feature → minor;
+fixes → patch. Document breaking changes in the changelog section.
+
+---
 
 ## Security
 
 This project has **not** been independently audited. Report vulnerabilities
-privately to the maintainers when possible; do not open public issues that
-include live seed material or private keys.
+privately to maintainers when possible. Never open public issues that include
+live seed material or private keys.
+
+---
 
 ## Getting help
 
-- Issues and PRs: [github.com/qntx/kobe](https://github.com/qntx/kobe)
-- Crate map: [`crates/README.md`](crates/README.md)
-- User-facing overview: [`README.md`](README.md)
+| Resource | Path |
+| --- | --- |
+| Issues / PRs | [github.com/qntx/kobe](https://github.com/qntx/kobe) |
+| Crate map | [`crates/README.md`](crates/README.md) |
+| User overview | [`README.md`](README.md) |
+| Agent architecture rules | [`AGENTS.md`](AGENTS.md) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,9 +646,10 @@ dependencies = [
 
 [[package]]
 name = "kobe"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "kobe-aptos",
+ "kobe-arweave",
  "kobe-btc",
  "kobe-casper",
  "kobe-cosmos",
@@ -666,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-aptos"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "hex",
  "kobe-primitives",
@@ -675,8 +676,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kobe-arweave"
+version = "3.4.0"
+dependencies = [
+ "base64",
+ "kobe-primitives",
+ "sha2 0.11.0",
+]
+
+[[package]]
 name = "kobe-btc"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "bech32",
  "bs58",
@@ -689,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-casper"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "blake2",
  "hex",
@@ -698,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-cli"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "clap",
  "colored",
@@ -710,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-cosmos"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "bech32",
  "kobe-primitives",
@@ -718,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-evm"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "alloy-primitives",
  "kobe-primitives",
@@ -726,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-fil"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "blake2",
  "kobe-primitives",
@@ -734,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-nostr"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "bech32",
  "kobe-primitives",
@@ -743,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-primitives"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "bip32",
  "bip39",
@@ -760,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-spark"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "bech32",
  "hex",
@@ -769,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-sui"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "blake2",
  "hex",
@@ -779,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-svm"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "bs58",
  "kobe-primitives",
@@ -788,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-ton"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "base64",
  "kobe-primitives",
@@ -798,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-tron"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "bs58",
  "kobe-primitives",
@@ -807,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-xrpl"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "bs58",
  "kobe-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude         = ["fuzz"]
 resolver        = "3"
 
 [workspace.package]
-version      = "3.3.0"
+version      = "3.4.0"
 edition      = "2024"
 # Minimum supported Rust version. `edition = "2024"` was stabilized in 1.85;
 # we pin to 1.85 here and enforce it in CI. Bumping this is a breaking change.
@@ -19,21 +19,22 @@ keywords     = ["crypto", "wallet", "bitcoin", "ethereum", "solana"]
 categories   = ["cryptography::cryptocurrencies"]
 
 [workspace.dependencies]
-kobe-primitives = { version = "3.3", path = "crates/kobe-primitives", default-features = false }
-kobe            = { version = "3.3", path = "crates/kobe",            default-features = false }
-kobe-btc        = { version = "3.3", path = "crates/kobe-btc",        default-features = false }
-kobe-cosmos     = { version = "3.3", path = "crates/kobe-cosmos",     default-features = false }
-kobe-evm        = { version = "3.3", path = "crates/kobe-evm",        default-features = false }
-kobe-fil        = { version = "3.3", path = "crates/kobe-fil",        default-features = false }
-kobe-spark      = { version = "3.3", path = "crates/kobe-spark",      default-features = false }
-kobe-sui        = { version = "3.3", path = "crates/kobe-sui",        default-features = false }
-kobe-svm        = { version = "3.3", path = "crates/kobe-svm",        default-features = false }
-kobe-ton        = { version = "3.3", path = "crates/kobe-ton",        default-features = false }
-kobe-tron       = { version = "3.3", path = "crates/kobe-tron",       default-features = false }
-kobe-aptos      = { version = "3.3", path = "crates/kobe-aptos",      default-features = false }
-kobe-nostr      = { version = "3.3", path = "crates/kobe-nostr",      default-features = false }
-kobe-xrpl       = { version = "3.3", path = "crates/kobe-xrpl",       default-features = false }
-kobe-casper     = { version = "3.3", path = "crates/kobe-casper",     default-features = false }
+kobe-primitives = { version = "3.4", path = "crates/kobe-primitives", default-features = false }
+kobe            = { version = "3.4", path = "crates/kobe",            default-features = false }
+kobe-btc        = { version = "3.4", path = "crates/kobe-btc",        default-features = false }
+kobe-cosmos     = { version = "3.4", path = "crates/kobe-cosmos",     default-features = false }
+kobe-evm        = { version = "3.4", path = "crates/kobe-evm",        default-features = false }
+kobe-fil        = { version = "3.4", path = "crates/kobe-fil",        default-features = false }
+kobe-spark      = { version = "3.4", path = "crates/kobe-spark",      default-features = false }
+kobe-sui        = { version = "3.4", path = "crates/kobe-sui",        default-features = false }
+kobe-svm        = { version = "3.4", path = "crates/kobe-svm",        default-features = false }
+kobe-ton        = { version = "3.4", path = "crates/kobe-ton",        default-features = false }
+kobe-tron       = { version = "3.4", path = "crates/kobe-tron",       default-features = false }
+kobe-aptos      = { version = "3.4", path = "crates/kobe-aptos",      default-features = false }
+kobe-nostr      = { version = "3.4", path = "crates/kobe-nostr",      default-features = false }
+kobe-xrpl       = { version = "3.4", path = "crates/kobe-xrpl",       default-features = false }
+kobe-casper     = { version = "3.4", path = "crates/kobe-casper",     default-features = false }
+kobe-arweave    = { version = "3.4", path = "crates/kobe-arweave",    default-features = false }
 
 alloy-primitives = { version = "1.6.1",  default-features = false, features = ["k256"] }
 base64           = { version = "0.23.1", default-features = false, features = ["alloc"] }

--- a/Justfile
+++ b/Justfile
@@ -39,6 +39,7 @@ check-no-std:
     cargo check -p kobe-nostr --no-default-features --features alloc
     cargo check -p kobe-xrpl --no-default-features --features alloc
     cargo check -p kobe-casper --no-default-features --features alloc
+    cargo check -p kobe-arweave --no-default-features --features alloc
     cargo check -p kobe --no-default-features --features alloc
     cargo check -p kobe --no-default-features --features "alloc,all-chains"
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ check-no-std:
 	cargo check -p kobe-nostr --no-default-features --features alloc
 	cargo check -p kobe-xrpl --no-default-features --features alloc
 	cargo check -p kobe-casper --no-default-features --features alloc
+	cargo check -p kobe-arweave --no-default-features --features alloc
 	cargo check -p kobe --no-default-features --features alloc
 	cargo check -p kobe --no-default-features --features "alloc,all-chains"
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 [rust-badge]: https://img.shields.io/badge/rust-edition%202024-orange.svg
 [rust-url]: https://doc.rust-lang.org/edition-guide/
 
-**`no_std`-compatible Rust toolkit for multi-chain HD wallet derivation — one BIP-39 seed, thirteen networks, zero hand-written cryptography, cross-implementation KATs.**
+**`no_std`-compatible Rust toolkit for multi-chain HD wallet derivation — one BIP-39 seed, fourteen networks, zero hand-written cryptography, cross-implementation KATs.**
 
-Kobe derives standards-compliant accounts and addresses for Aptos, Bitcoin, Ethereum, Solana, Cosmos, Tron, Sui, TON, Filecoin, Spark, XRP Ledger, Nostr (NIP-06 / NIP-19), and Casper from a single BIP-39 mnemonic. It layers thin wrappers around [`bip39`](https://docs.rs/bip39), [`bip32`](https://docs.rs/bip32), [`k256`](https://docs.rs/k256), and [`ed25519-dalek`](https://docs.rs/ed25519-dalek) on top of a unified `Wallet` + `Derive` trait surface (Bitcoin address/WIF encoding is local in `kobe-btc`, not the full `bitcoin` crate); every library crate builds under `no_std + alloc`, mnemonics and private keys wrap in `Zeroizing<T>` and wipe on drop, and every chain's pipeline is pinned against independent reference implementations (bitcoinjs-lib, @ton/core, @noble/hashes, NIP-06 official vectors, ethanmarcuss/spark-address, casper-types AccountHash preimage, …).
+Kobe derives standards-compliant accounts and addresses for Aptos, Bitcoin, Ethereum, Solana, Cosmos, Tron, Sui, TON, Filecoin, Spark, XRP Ledger, Arweave (ECDSA), Nostr (NIP-06 / NIP-19), and Casper from a single BIP-39 mnemonic. It layers thin wrappers around [`bip39`](https://docs.rs/bip39), [`bip32`](https://docs.rs/bip32), [`k256`](https://docs.rs/k256), and [`ed25519-dalek`](https://docs.rs/ed25519-dalek) on top of a unified `Wallet` + `Derive` trait surface (Bitcoin address/WIF encoding is local in `kobe-btc`, not the full `bitcoin` crate); every library crate builds under `no_std + alloc`, mnemonics and private keys wrap in `Zeroizing<T>` and wipe on drop, and every chain's pipeline is pinned against independent reference implementations (bitcoinjs-lib, @ton/core, @noble/hashes, NIP-06 official vectors, ethanmarcuss/spark-address, casper-types AccountHash preimage, Arweave `ar_wallet` / arweave-js `master-ec`, …).
 
 > **See also** [`signer`](https://github.com/qntx/signer) — the companion transaction-signing toolkit that consumes kobe's derived accounts via `Signer::from_derived`.
 
@@ -72,6 +72,7 @@ kobe fil    new                              # Filecoin (`f1…` secp256k1)
 kobe spark  new                              # Spark (Bitcoin L2), bech32m `spark1…`
 kobe spark  new --network testnet            # Spark testnet (`sparkt1…`)
 kobe xrpl   new                              # XRP Ledger classic `r…`
+kobe arweave new                             # Arweave ECDSA (Base64URL, coin 472)
 kobe nostr  new                              # Nostr NIP-06 (`nsec` / `npub`, NIP-19)
 
 # Import from an existing mnemonic
@@ -93,7 +94,7 @@ kobe upgrade --force                     # reinstall even when up to date
 echo "abandon abandon ... about" | kobe -r evm import -m -
 ```
 
-Every chain subcommand accepts the shared flags `-w/--words`, `-c/--count`, `-p/--passphrase`, and `--qr` through a flattened `SimpleArgs` group, so ergonomics stay consistent across the 13 networks. Global `-r` / `--reveal` opts into printing mnemonics and private keys (default: hidden).
+Every chain subcommand accepts the shared flags `-w/--words`, `-c/--count`, `-p/--passphrase`, and `--qr` through a flattened `SimpleArgs` group, so ergonomics stay consistent across the 14 networks. Global `-r` / `--reveal` opts into printing mnemonics and private keys (default: hidden).
 
 ### Library Usage
 
@@ -174,6 +175,7 @@ println!("Mnemonic: {}", wallet.mnemonic());
 | Filecoin   | `kobe-fil`     | secp256k1 (BIP-32)    | 461         | `m/44'/461'/0'/0/{i}`       | Base32 `f1…`                             |
 | Spark      | `kobe-spark`   | secp256k1 (BIP-32)    | 8797555 †   | `m/8797555'/{i}'/0'`        | Bech32m `spark1…` / `sparkt1…` / …       |
 | XRP Ledger | `kobe-xrpl`    | secp256k1 (BIP-32)    | 144         | `m/44'/144'/0'/0/{i}`       | Base58Check (XRPL alphabet) `r…`         |
+| Arweave    | `kobe-arweave` | secp256k1 (BIP-32)    | 472         | `m/44'/472'/0'/0/{i}`       | Base64URL(SHA-256(compressed pk)) §      |
 | Nostr      | `kobe-nostr`   | secp256k1 (BIP-340)   | 1237        | `m/44'/1237'/{i}'/0/0`      | NIP-19 `npub1…` / `nsec1…`               |
 | Solana     | `kobe-svm`     | Ed25519 (SLIP-10)     | 501         | `m/44'/501'/{i}'/0'`        | Base58 + optional 64-byte keypair        |
 | Sui        | `kobe-sui`     | Ed25519 (SLIP-10)     | 784         | `m/44'/784'/{i}'/0'/0'`     | `0x` + hex(`BLAKE2b-256(0x00 ‖ pubkey)`) |
@@ -184,10 +186,11 @@ println!("Mnemonic: {}", wallet.mnemonic());
 \* Cosmos coin type defaults to `118`; Terra (`330`), Secret (`529`), Kava (`459`), and custom chains are selectable via `ChainConfig`.
 † Spark purpose `8797555` is Spark-specific (`SHA-256("spark")` truncated), not a BIP-44 assignment.
 ‡ Casper default is secp256k1 (Ledger); Ed25519 uses `m/44'/506'/0'/0'/{i}'`. AccountHash preimage is `algorithm_name || 0x00 || raw_pubkey` per `casper-types`.
+§ Arweave ECDSA only (2.9+). Not an Ethereum address. RSA-PSS JWK wallets are out of scope.
 
 ## Design
 
-- **13 chains** — Aptos, Bitcoin, Ethereum, Solana, Cosmos, Tron, Sui, TON, Filecoin, Spark, XRP Ledger, Nostr, Casper — one BIP-39 seed
+- **14 chains** — Aptos, Bitcoin, Ethereum, Solana, Cosmos, Tron, Sui, TON, Filecoin, Spark, XRP Ledger, Arweave (ECDSA), Nostr, Casper — one BIP-39 seed
 - **Mature crypto dependencies** — `bip39` for mnemonic ↔ entropy, `bip32` + `k256` for BIP-32 secp256k1 (via `kobe-primitives`), `ed25519-dalek` for SLIP-10 Ed25519; hashing via `sha2` / `sha3` / `blake2` / `ripemd`; encoding via `bech32` / `bs58` (Bitcoin addresses/WIF implemented in-tree and KAT-pinned)
 - **Unified derivation contract** — shared `Derive` trait with an associated `Account` type + shared `DerivationStyle` trait; every chain has typed public keys via `DerivedPublicKey`, one shared `DeriveError`, and one shared `ParseDerivationStyleError`
 - **Consistent entry points** — `derive` / `derive_with` / `derive_at` / `derive_at_with` across every chain (Bitcoin's structured path also available as `derive_structured`)

--- a/crates/README.md
+++ b/crates/README.md
@@ -15,6 +15,7 @@
 | **[`kobe-fil`](kobe-fil/)** | [![crates.io][kobe-fil-crate]][kobe-fil-crate-url] [![docs.rs][kobe-fil-doc]][kobe-fil-doc-url] | Filecoin — f1 secp256k1 addresses |
 | **[`kobe-spark`](kobe-spark/)** | [![crates.io][kobe-spark-crate]][kobe-spark-crate-url] [![docs.rs][kobe-spark-doc]][kobe-spark-doc-url] | Spark (Bitcoin L2) — identity keys + Bech32m `spark1…` addresses |
 | **[`kobe-xrpl`](kobe-xrpl/)** | [![crates.io][kobe-xrpl-crate]][kobe-xrpl-crate-url] [![docs.rs][kobe-xrpl-doc]][kobe-xrpl-doc-url] | XRP Ledger — classic `r`-addresses, secp256k1 |
+| **[`kobe-arweave`](kobe-arweave/)** | [![crates.io][kobe-arweave-crate]][kobe-arweave-crate-url] [![docs.rs][kobe-arweave-doc]][kobe-arweave-doc-url] | Arweave — ECDSA secp256k1, Base64URL(SHA-256(compressed pk)) |
 | **[`kobe-nostr`](kobe-nostr/)** | [![crates.io][kobe-nostr-crate]][kobe-nostr-crate-url] [![docs.rs][kobe-nostr-doc]][kobe-nostr-doc-url] | Nostr — NIP-06 key derivation, NIP-19 bech32 `nsec`/`npub` |
 | **[`kobe-casper`](kobe-casper/)** | [![crates.io][kobe-casper-crate]][kobe-casper-crate-url] [![docs.rs][kobe-casper-doc]][kobe-casper-doc-url] | Casper — secp256k1 / Ed25519 HD + AccountHash |
 | **[`kobe-cli`](kobe-cli/)** | [![crates.io][kobe-cli-crate]][kobe-cli-crate-url] | CLI — generate, import, derive; `upgrade` via sh.qntx.fun |
@@ -36,8 +37,9 @@ kobe-cli
         ├── kobe-svm    ── kobe-primitives/slip10
         ├── kobe-ton    ── kobe-primitives/slip10
         ├── kobe-tron   ── kobe-primitives/bip32
-        ├── kobe-xrpl   ── kobe-primitives/bip32
-        └── kobe-casper ── kobe-primitives/bip32 + slip10
+        ├── kobe-xrpl    ── kobe-primitives/bip32
+        ├── kobe-arweave ── kobe-primitives/bip32
+        └── kobe-casper  ── kobe-primitives/bip32 + slip10
 ```
 
 All chain crates consume key derivation through the wallet-level shortcuts
@@ -69,6 +71,7 @@ The umbrella `kobe` crate provides fine-grained feature control:
 | `xrpl` | | XRP Ledger chain support (enables `bip32`) |
 | `nostr` | | Nostr chain support (enables `bip32`) |
 | `casper` | | Casper Network support (enables `bip32` + `slip10`) |
+| `arweave` | | Arweave ECDSA support (enables `bip32`) |
 | `all-chains` | | Enable all chain crates |
 
 [kobe-crate]: https://img.shields.io/crates/v/kobe.svg
@@ -133,3 +136,7 @@ The umbrella `kobe` crate provides fine-grained feature control:
 [kobe-casper-crate-url]: https://crates.io/crates/kobe-casper
 [kobe-casper-doc]: https://img.shields.io/docsrs/kobe-casper.svg
 [kobe-casper-doc-url]: https://docs.rs/kobe-casper
+[kobe-arweave-crate]: https://img.shields.io/crates/v/kobe-arweave.svg
+[kobe-arweave-crate-url]: https://crates.io/crates/kobe-arweave
+[kobe-arweave-doc]: https://img.shields.io/docsrs/kobe-arweave.svg
+[kobe-arweave-doc-url]: https://docs.rs/kobe-arweave

--- a/crates/kobe-arweave/Cargo.toml
+++ b/crates/kobe-arweave/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name                   = "kobe-arweave"
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+repository.workspace   = true
+readme                 = "../../README.md"
+description            = "Arweave ECDSA (secp256k1) wallet for Kobe"
+keywords               = ["arweave", "wallet", "crypto", "ecdsa", "no_std"]
+categories             = ["cryptography", "no-std"]
+
+[features]
+default = ["std"]
+std     = ["alloc", "kobe-primitives/std"]
+alloc   = ["kobe-primitives/alloc"]
+
+[dependencies]
+base64.workspace  = true
+kobe-primitives   = { workspace = true, features = ["bip32"] }
+sha2.workspace    = true
+
+[lints]
+workspace = true

--- a/crates/kobe-arweave/src/deriver.rs
+++ b/crates/kobe-arweave/src/deriver.rs
@@ -1,0 +1,215 @@
+//! Arweave ECDSA address derivation from a unified wallet.
+//!
+//! ## Address algorithm (protocol + `arweave-js` `master-ec`)
+//!
+//! 1. Derive a secp256k1 key pair at `m/44'/472'/0'/0/{index}` (SLIP-44 coin 472).
+//! 2. Take the **33-byte compressed** public key (`ECDSA_PUB_KEY_SIZE` in
+//!    `ar.hrl`; `compress_ecdsa_pubkey/1` in `ar_wallet.erl`;
+//!    `SECP256K1_IDENTIFIER_SIZE` in `arweave-js`).
+//! 3. `SHA-256(compressed_pubkey)` → 32 bytes.
+//! 4. Encode with [`Base64URL`] without padding into a 43-character address string.
+//!
+//! [`Base64URL`]: https://datatracker.ietf.org/doc/html/rfc4648#section-5
+//!
+//! This is **not** an Ethereum address (no Keccak-256 truncation). Hashing the
+//! uncompressed 65-byte SEC1 point yields a different address and is wrong.
+//!
+//! Signing (65-byte recoverable ECDSA, empty `owner`, format=2) belongs in a
+//! companion signer crate, not here.
+
+#[cfg(feature = "alloc")]
+use alloc::{format, string::String};
+
+use base64::Engine;
+use kobe_primitives::{Derive, DeriveError, DerivedAccount, DerivedPublicKey, Wallet};
+use sha2::{Digest, Sha256};
+
+/// Encode a compressed secp256k1 public key as an Arweave address.
+///
+/// `Base64URL_nopad(SHA-256(pk))` — same preimage as the node for ECDSA wallets.
+#[must_use]
+pub fn address_from_compressed_pubkey(pk: &[u8; 33]) -> String {
+    let digest = Sha256::digest(pk);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest)
+}
+
+/// Encode a compressed public key as the recovered ECDSA **owner** string.
+///
+/// On format-2 ECDSA transactions the `owner` field is empty and clients
+/// recover this value (`Base64URL` of the 33-byte identifier), not the account address.
+#[must_use]
+pub fn owner_from_compressed_pubkey(pk: &[u8; 33]) -> String {
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(pk)
+}
+
+/// Arweave ECDSA address deriver.
+///
+/// Uses BIP-44 coin type 472 with secp256k1. RSA is not supported.
+#[derive(Debug)]
+pub struct Deriver<'a> {
+    /// Wallet seed reference.
+    wallet: &'a Wallet,
+}
+
+impl<'a> Deriver<'a> {
+    /// Create an Arweave ECDSA deriver.
+    #[must_use]
+    pub const fn new(wallet: &'a Wallet) -> Self {
+        Self { wallet }
+    }
+
+    /// Derive at an arbitrary BIP-32 path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if key derivation fails.
+    pub fn derive_at(&self, path: &str) -> Result<DerivedAccount, DeriveError> {
+        let key = self.wallet.derive_secp256k1(path)?;
+        let pubkey_bytes = key.compressed_pubkey();
+        let address = address_from_compressed_pubkey(&pubkey_bytes);
+
+        Ok(DerivedAccount::new(
+            path.into(),
+            key.private_key_bytes(),
+            DerivedPublicKey::Secp256k1Compressed(pubkey_bytes),
+            address,
+        ))
+    }
+}
+
+impl Derive for Deriver<'_> {
+    type Account = DerivedAccount;
+    type Error = DeriveError;
+
+    fn derive(&self, index: u32) -> Result<DerivedAccount, DeriveError> {
+        let path = format!("m/44'/472'/0'/0/{index}");
+        self.derive_at(&path)
+    }
+
+    fn derive_path(&self, path: &str) -> Result<DerivedAccount, DeriveError> {
+        self.derive_at(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use kobe_primitives::DeriveExt;
+
+    use super::*;
+
+    /// Canonical BIP-39 test mnemonic (12 × `abandon` + `about`).
+    const MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    fn wallet() -> Wallet {
+        Wallet::from_mnemonic(MNEMONIC, None).unwrap()
+    }
+
+    /// Known-answer: BIP-39 abandon → BIP-32 `m/44'/472'/0'/0/0` → compressed pk
+    /// → Base64URL(SHA-256). Cross-checked with `@scure/bip32` + `@noble/hashes`.
+    #[test]
+    fn kat_arweave_abandon_index0() {
+        let a = Deriver::new(&wallet()).derive(0).unwrap();
+        assert_eq!(a.path(), "m/44'/472'/0'/0/0");
+        assert_eq!(a.address(), "G3y00z9F3EvSzJprpIH6vPqHVZPH0rLqLrg0JOsd88Y");
+        assert_eq!(
+            a.private_key_hex().as_str(),
+            "130721c87ce0ace0999c94a5943d055b224411eda752680ca24969d0837ff152"
+        );
+        assert_eq!(a.address().len(), 43);
+    }
+
+    #[test]
+    fn kat_arweave_abandon_index1() {
+        let a = Deriver::new(&wallet()).derive(1).unwrap();
+        assert_eq!(a.path(), "m/44'/472'/0'/0/1");
+        assert_eq!(a.address(), "s67JULQPjY6wpxYV4imfx_Ui6twtC_jfxnluJT4GOSo");
+        assert_eq!(
+            a.private_key_hex().as_str(),
+            "a8822ffcffba36d726f8ddd866963325b668c36d780f73fcf245a59babd8aa12"
+        );
+    }
+
+    #[test]
+    fn address_from_compressed_pubkey_matches_kat() {
+        let key = wallet().derive_secp256k1("m/44'/472'/0'/0/0").unwrap();
+        let pk = key.compressed_pubkey();
+        assert_eq!(
+            key.compressed_pubkey_hex(),
+            "03df9a82774ebbcd956bb1bd8a7851f25a95dcb11b064a74ccadcf277ccb6d3b6f"
+        );
+        assert_eq!(
+            address_from_compressed_pubkey(&pk),
+            "G3y00z9F3EvSzJprpIH6vPqHVZPH0rLqLrg0JOsd88Y"
+        );
+    }
+
+    #[test]
+    fn owner_from_compressed_pubkey_index0() {
+        let key = wallet().derive_secp256k1("m/44'/472'/0'/0/0").unwrap();
+        assert_eq!(
+            owner_from_compressed_pubkey(&key.compressed_pubkey()),
+            "A9-agndOu82Va7G9inhR8lqV3LEbBkp0zK3PJ3zLbTtv"
+        );
+    }
+
+    /// Hashing the uncompressed SEC1 point must not produce the protocol address.
+    #[test]
+    fn uncompressed_pubkey_yields_different_address() {
+        let key = wallet().derive_secp256k1("m/44'/472'/0'/0/0").unwrap();
+        let compressed = key.compressed_pubkey();
+        let uncompressed = key.uncompressed_pubkey();
+        let wrong = {
+            let digest = Sha256::digest(uncompressed);
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest)
+        };
+        assert_ne!(address_from_compressed_pubkey(&compressed), wrong);
+        assert_eq!(
+            wrong.as_str(),
+            "eOqGD0loQiFvP7w-aQNq1DoVyTJM_eUnPG78vKY3JIM"
+        );
+    }
+
+    #[test]
+    fn address_charset_and_length() {
+        let a = Deriver::new(&wallet()).derive(0).unwrap();
+        assert_eq!(a.address().len(), 43);
+        assert!(
+            a.address()
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        );
+    }
+
+    #[test]
+    fn derive_many_matches_individual() {
+        let w = wallet();
+        let d = Deriver::new(&w);
+        let batch = d.derive_many(0, 3).unwrap();
+        let single: Vec<_> = (0..3).map(|i| d.derive(i).unwrap()).collect();
+        for (b, s) in batch.iter().zip(single.iter()) {
+            assert_eq!(b.address(), s.address());
+            assert_eq!(b.path(), s.path());
+        }
+    }
+
+    #[test]
+    fn passphrase_changes_derivation() {
+        let w_no_pw = Wallet::from_mnemonic(MNEMONIC, None).unwrap();
+        let w_pw = Wallet::from_mnemonic(MNEMONIC, Some("TREZOR")).unwrap();
+        assert_ne!(
+            Deriver::new(&w_no_pw).derive(0).unwrap().address(),
+            Deriver::new(&w_pw).derive(0).unwrap().address(),
+        );
+    }
+
+    #[test]
+    fn derive_path_honours_account_segment() {
+        let w = wallet();
+        let default_addr = Deriver::new(&w).derive(0).unwrap().address().to_owned();
+        let alt = Deriver::new(&w).derive_path("m/44'/472'/1'/0/0").unwrap();
+        assert_eq!(alt.path(), "m/44'/472'/1'/0/0");
+        assert_ne!(alt.address(), default_addr);
+    }
+}

--- a/crates/kobe-arweave/src/lib.rs
+++ b/crates/kobe-arweave/src/lib.rs
@@ -1,0 +1,17 @@
+//! Arweave ECDSA (secp256k1) wallet utilities for Kobe.
+//!
+//! Offline HD derivation only: BIP-44 coin type **472**, compressed public key,
+//! address = `Base64URL(SHA-256(compressed_pk))`. RSA and transaction signing
+//! are out of scope (see crate docs on [`Deriver`]).
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "alloc")]
+mod deriver;
+
+#[cfg(feature = "alloc")]
+pub use deriver::{Deriver, address_from_compressed_pubkey, owner_from_compressed_pubkey};
+pub use kobe_primitives::{DeriveError, DerivedAccount, DerivedPublicKey};

--- a/crates/kobe-casper/src/address.rs
+++ b/crates/kobe-casper/src/address.rs
@@ -5,7 +5,9 @@
 //! - **Tagged public key** (serialization / display hex): tag byte + raw key.
 //! - **`AccountHash`** preimage: `algorithm_name || 0x00 || raw_key` (no tag).
 
-use alloc::{format, string::String, vec::Vec};
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 use blake2::Blake2bVar;
 use blake2::digest::{Update, VariableOutput};

--- a/crates/kobe-cli/src/commands/arweave.rs
+++ b/crates/kobe-cli/src/commands/arweave.rs
@@ -1,0 +1,26 @@
+//! Arweave ECDSA wallet CLI commands.
+
+use clap::Args;
+use kobe::DeriveExt;
+use kobe::arweave::Deriver;
+
+use crate::commands::SimpleSubcommand;
+
+/// Arweave ECDSA wallet operations (SLIP-44 coin type 472).
+#[derive(Args, Debug)]
+pub(crate) struct ArweaveCommand {
+    #[command(subcommand)]
+    command: SimpleSubcommand,
+}
+
+impl ArweaveCommand {
+    pub(crate) fn execute(
+        self,
+        json: bool,
+        reveal: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.command.execute("arweave", json, reveal, |w, n| {
+            Ok(Deriver::new(w).derive_many(0, n)?)
+        })
+    }
+}

--- a/crates/kobe-cli/src/commands/mod.rs
+++ b/crates/kobe-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 //! CLI command definitions and handlers.
 
 mod aptos;
+mod arweave;
 mod bitcoin;
 mod casper;
 mod cosmos;
@@ -18,6 +19,7 @@ mod update;
 mod xrpl;
 
 pub(crate) use aptos::AptosCommand;
+pub(crate) use arweave::ArweaveCommand;
 pub(crate) use bitcoin::BitcoinCommand;
 pub(crate) use casper::CasperCommand;
 use clap::{Parser, Subcommand};
@@ -107,6 +109,10 @@ pub(crate) enum Commands {
     /// Casper Network wallet operations.
     #[command(name = "casper", alias = "cspr")]
     Casper(CasperCommand),
+
+    /// Arweave ECDSA wallet operations (SLIP-44 coin type 472).
+    #[command(name = "arweave", alias = "ar")]
+    Arweave(ArweaveCommand),
 
     /// Mnemonic utilities (camouflage encrypt/decrypt).
     #[command(name = "mnemonic", alias = "mn")]

--- a/crates/kobe-cli/src/commands/simple.rs
+++ b/crates/kobe-cli/src/commands/simple.rs
@@ -1,9 +1,10 @@
 //! Shared command template for simple chains.
 //!
 //! Chains without network/address-type/style parameters (Aptos, Sui, Spark,
-//! Filecoin, Tron, XRPL, TON, Nostr, Casper, …) all expose the same `new` / `import`
-//! surface. This module provides a single generic subcommand reused by each
-//! chain's thin wrapper, eliminating hundreds of lines of boilerplate.
+//! Filecoin, Tron, XRPL, Arweave, TON, Nostr, Casper, …) all expose the same
+//! `new` / `import` surface. This module provides a single generic subcommand
+//! reused by each chain's thin wrapper, eliminating hundreds of lines of
+//! boilerplate.
 
 use std::io::{self, BufRead};
 

--- a/crates/kobe-cli/src/main.rs
+++ b/crates/kobe-cli/src/main.rs
@@ -49,6 +49,7 @@ fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Commands::Xrpl(cmd) => cmd.execute(json, reveal)?,
         Commands::Nostr(cmd) => cmd.execute(json, reveal)?,
         Commands::Casper(cmd) => cmd.execute(json, reveal)?,
+        Commands::Arweave(cmd) => cmd.execute(json, reveal)?,
         Commands::Mnemonic(cmd) => cmd.execute(json, reveal)?,
         Commands::Upgrade(cmd) => cmd.execute(json)?,
     }

--- a/crates/kobe-primitives/src/derive.rs
+++ b/crates/kobe-primitives/src/derive.rs
@@ -32,7 +32,7 @@ use crate::DeriveError;
 ///
 /// | Chain(s) | Variant | Length |
 /// | --- | --- | --- |
-/// | `kobe-btc`, `kobe-cosmos`, `kobe-spark`, `kobe-xrpl`, `kobe-casper` (secp) | [`Secp256k1Compressed`](Self::Secp256k1Compressed) | 33 B |
+/// | `kobe-btc`, `kobe-cosmos`, `kobe-spark`, `kobe-xrpl`, `kobe-arweave`, `kobe-casper` (secp) | [`Secp256k1Compressed`](Self::Secp256k1Compressed) | 33 B |
 /// | `kobe-evm`, `kobe-fil`, `kobe-tron` | [`Secp256k1Uncompressed`](Self::Secp256k1Uncompressed) | 65 B |
 /// | `kobe-svm`, `kobe-sui`, `kobe-aptos`, `kobe-ton`, `kobe-casper` (ed25519) | [`Ed25519`](Self::Ed25519) | 32 B |
 /// | `kobe-nostr` | [`Secp256k1XOnly`](Self::Secp256k1XOnly) | 32 B |

--- a/crates/kobe-primitives/src/lib.rs
+++ b/crates/kobe-primitives/src/lib.rs
@@ -16,8 +16,8 @@
 //!                    │           │
 //!    used by BTC / EVM /         │  used by Solana / Sui /
 //!    Cosmos / Tron / Spark /     │  Aptos / TON /
-//!    Fil / XRPL / Nostr /        │  Casper (ed25519)
-//!    Casper (secp)               │
+//!    Fil / XRPL / Arweave /      │  Casper (ed25519)
+//!    Nostr / Casper (secp)       │
 //!                    └─────┬─────┘
 //!                          ▼
 //!                   DerivedAccount  ─◄── every chain wraps this

--- a/crates/kobe/Cargo.toml
+++ b/crates/kobe/Cargo.toml
@@ -15,8 +15,8 @@ categories             = ["cryptography::cryptocurrencies"]
 # (`mainstream`, `all-chains`) to keep binary size and compile time predictable.
 default = ["std"]
 
-std        = ["alloc", "kobe-primitives/std", "kobe-aptos?/std", "kobe-btc?/std", "kobe-evm?/std", "kobe-svm?/std", "kobe-cosmos?/std", "kobe-tron?/std", "kobe-spark?/std", "kobe-fil?/std", "kobe-ton?/std", "kobe-sui?/std", "kobe-nostr?/std", "kobe-xrpl?/std", "kobe-casper?/std"]
-alloc      = ["kobe-primitives/alloc", "kobe-aptos?/alloc", "kobe-btc?/alloc", "kobe-evm?/alloc", "kobe-svm?/alloc", "kobe-cosmos?/alloc", "kobe-tron?/alloc", "kobe-spark?/alloc", "kobe-fil?/alloc", "kobe-ton?/alloc", "kobe-sui?/alloc", "kobe-nostr?/alloc", "kobe-xrpl?/alloc", "kobe-casper?/alloc"]
+std        = ["alloc", "kobe-primitives/std", "kobe-aptos?/std", "kobe-btc?/std", "kobe-evm?/std", "kobe-svm?/std", "kobe-cosmos?/std", "kobe-tron?/std", "kobe-spark?/std", "kobe-fil?/std", "kobe-ton?/std", "kobe-sui?/std", "kobe-nostr?/std", "kobe-xrpl?/std", "kobe-casper?/std", "kobe-arweave?/std"]
+alloc      = ["kobe-primitives/alloc", "kobe-aptos?/alloc", "kobe-btc?/alloc", "kobe-evm?/alloc", "kobe-svm?/alloc", "kobe-cosmos?/alloc", "kobe-tron?/alloc", "kobe-spark?/alloc", "kobe-fil?/alloc", "kobe-ton?/alloc", "kobe-sui?/alloc", "kobe-nostr?/alloc", "kobe-xrpl?/alloc", "kobe-casper?/alloc", "kobe-arweave?/alloc"]
 rand       = ["kobe-primitives/rand"]
 rand_core  = ["kobe-primitives/rand_core"]
 camouflage = ["kobe-primitives/camouflage"]
@@ -37,12 +37,13 @@ sui    = ["dep:kobe-sui", "slip10"]
 aptos  = ["dep:kobe-aptos", "slip10"]
 nostr  = ["dep:kobe-nostr", "bip32"]
 xrpl   = ["dep:kobe-xrpl", "bip32"]
-casper = ["dep:kobe-casper", "bip32", "slip10"]
+casper  = ["dep:kobe-casper", "bip32", "slip10"]
+arweave = ["dep:kobe-arweave", "bip32"]
 
 # Preset: the three most requested chains (previous 1.x default).
 mainstream = ["btc", "evm", "svm"]
 # Preset: every chain crate.
-all-chains = ["aptos", "btc", "evm", "svm", "cosmos", "tron", "spark", "fil", "ton", "sui", "nostr", "xrpl", "casper"]
+all-chains = ["aptos", "btc", "evm", "svm", "cosmos", "tron", "spark", "fil", "ton", "sui", "nostr", "xrpl", "casper", "arweave"]
 
 [dependencies]
 kobe-primitives = { workspace = true, features = ["alloc"] }
@@ -59,6 +60,7 @@ kobe-sui        = { workspace = true, optional = true }
 kobe-nostr      = { workspace = true, optional = true }
 kobe-xrpl       = { workspace = true, optional = true }
 kobe-casper     = { workspace = true, optional = true }
+kobe-arweave    = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/kobe/src/lib.rs
+++ b/crates/kobe/src/lib.rs
@@ -24,6 +24,8 @@
 
 #[cfg(feature = "aptos")]
 pub use kobe_aptos as aptos;
+#[cfg(feature = "arweave")]
+pub use kobe_arweave as arweave;
 #[cfg(feature = "btc")]
 pub use kobe_btc as btc;
 #[cfg(feature = "casper")]

--- a/crates/kobe/tests/cross_chain_smoke.rs
+++ b/crates/kobe/tests/cross_chain_smoke.rs
@@ -159,6 +159,14 @@ mod smoke {
     }
 
     #[test]
+    fn arweave_ecdsa() {
+        let w = wallet();
+        let a = kobe::arweave::Deriver::new(&w).derive(0).unwrap();
+        assert_eq!(a.address(), "G3y00z9F3EvSzJprpIH6vPqHVZPH0rLqLrg0JOsd88Y");
+        assert_eq!(a.path(), "m/44'/472'/0'/0/0");
+    }
+
+    #[test]
     fn derive_many_agrees() {
         let w = wallet();
         let d = kobe::evm::Deriver::new(&w);

--- a/skills/kobe/SKILL.md
+++ b/skills/kobe/SKILL.md
@@ -2,16 +2,17 @@
 name: kobe
 description: >-
   Multi-chain cryptocurrency wallet CLI tool for generating, importing, and
-  managing HD wallets across 13 chains: Aptos, Bitcoin, Ethereum, Solana, Cosmos,
-  Tron, Sui, TON, Filecoin, Spark, XRP Ledger, Nostr, and Casper. Use when the user
-  asks to create wallets, generate addresses, derive keys, import mnemonics,
-  produce NIP-19 `npub` / `nsec` identities, Casper account-hash addresses, or
-  perform any cryptocurrency wallet operation. Supports JSON output via --json flag.
+  managing HD wallets across 14 chains: Aptos, Bitcoin, Ethereum, Solana, Cosmos,
+  Tron, Sui, TON, Filecoin, Spark, XRP Ledger, Arweave (ECDSA), Nostr, and Casper.
+  Use when the user asks to create wallets, generate addresses, derive keys,
+  import mnemonics, produce NIP-19 `npub` / `nsec` identities, Casper
+  account-hash addresses, Arweave Base64URL addresses, or perform any
+  cryptocurrency wallet operation. Supports JSON output via --json flag.
 ---
 
 # Kobe CLI — Multi-Chain HD Wallet Tool
 
-`kobe` is a single binary CLI for generating and managing cryptocurrency wallets across **13 chains**: Aptos, Bitcoin, Ethereum, Solana, Cosmos, Tron, Sui, TON, Filecoin, Spark, XRP Ledger, Nostr, and Casper. It supports BIP-39 mnemonic generation, HD key derivation (BIP-32/44/49/84/86, SLIP-10, NIP-06), multiple derivation styles for hardware wallet compatibility, NIP-19 bech32 output for Nostr, Casper AccountHash addresses, and mnemonic camouflage encryption.
+`kobe` is a single binary CLI for generating and managing cryptocurrency wallets across **14 chains**: Aptos, Bitcoin, Ethereum, Solana, Cosmos, Tron, Sui, TON, Filecoin, Spark, XRP Ledger, Arweave (ECDSA), Nostr, and Casper. It supports BIP-39 mnemonic generation, HD key derivation (BIP-32/44/49/84/86, SLIP-10, NIP-06), multiple derivation styles for hardware wallet compatibility, NIP-19 bech32 output for Nostr, Casper AccountHash addresses, Arweave ECDSA Base64URL addresses, and mnemonic camouflage encryption.
 
 ## Installation
 
@@ -73,6 +74,7 @@ The `--json` and `-r` / `--reveal` flags are **global**. When `--json` is set, a
 | Filecoin   | `fil`      | `filecoin`        |
 | Spark      | `spark`    | —                 |
 | XRP Ledger | `xrpl`     | `xrp`, `ripple`   |
+| Arweave    | `arweave`  | `ar`              |
 | Nostr      | `nostr`    | —                 |
 | Casper     | `casper`   | `cspr`            |
 | Mnemonic   | `mnemonic` | `mn`              |
@@ -295,6 +297,10 @@ kobe spark new --network local     # sparkl1...
 # XRP Ledger
 kobe xrpl new
 
+# Arweave ECDSA (Base64URL(SHA-256(compressed pk)), path m/44'/472'/0'/0/{i})
+kobe arweave new
+kobe ar new -c 3
+
 # Casper (default secp256k1 Ledger path → account-hash-…)
 kobe casper new
 kobe casper new --algo ed25519 -c 3
@@ -417,6 +423,7 @@ All errors in JSON mode return exit code 1 with:
 | Filecoin   | 64-char hex string                                                       |
 | Spark      | 64-char hex string (compressed pubkey also provided)                     |
 | XRP Ledger | 64-char hex string                                                       |
+| Arweave    | 64-char hex string (ECDSA secp256k1; address is Base64URL 43 chars)      |
 | Nostr      | NIP-19 bech32 `nsec1…` (64-char hex also available; address is `npub1…`) |
 | Casper     | 64-char hex string (secp256k1 or Ed25519 secret; address is `account-hash-…`) |
 
@@ -505,6 +512,14 @@ Address: Bech32m-encoded compressed identity public key wrapped in a
 | Path Pattern          | Address Format     |
 | --------------------- | ------------------ |
 | `m/44'/144'/0'/0/{i}` | Base58Check `r...` |
+
+### Arweave ECDSA (BIP-44, SLIP-44 coin 472)
+
+| Path Pattern          | Address Format |
+| --------------------- | -------------- |
+| `m/44'/472'/0'/0/{i}` | Base64URL(SHA-256(compressed 33-byte secp256k1 pk)), 43 chars |
+
+Not an Ethereum address. RSA wallets are not supported by this command.
 
 ### Nostr (NIP-06)
 


### PR DESCRIPTION
## Summary

- Add **`kobe-arweave`**: ECDSA-only offline HD (SLIP-44 **472**), path `m/44'/472'/0'/0/{i}`
- Address = **Base64URL_nopad(SHA-256(compressed 33-byte secp256k1 pubkey))** — matches node `ar_wallet` (`ECDSA_PUB_KEY_SIZE = 33`) and arweave-js `master-ec` identifier hash
- Helpers: `address_from_compressed_pubkey`, `owner_from_compressed_pubkey` (recovered owner when tx `owner` is empty)
- CLI: `kobe arweave` / `kobe ar` (`new` / `import`)
- Umbrella feature `arweave` in `all-chains` (not `mainstream`)
- Wire **CI** thumb no_std + **publish.yml** crates.io order
- Workspace **3.4.0**; rewrite **CONTRIBUTING.md** chain registration matrix (CI/publish rows explicit)
- Explicit non-goals: RSA wallets, transaction signing

## Protocol

| Item | Value |
| --- | --- |
| Curve | secp256k1 |
| Pubkey | compressed 33 B |
| Address | Base64URL(SHA-256(pk)), 43 chars |
| Path | `m/44'/472'/0'/0/{i}` |
| KAT abandon@0 | `G3y00z9F3EvSzJprpIH6vPqHVZPH0rLqLrg0JOsd88Y` |
| KAT abandon@1 | `s67JULQPjY6wpxYV4imfx_Ui6twtC_jfxnluJT4GOSo` |

Sources: [ECDSA Keys](https://docs.arweave.org/developers/development/overview/ecdsa-keys), `ar_wallet.erl`, arweave-js `origin/master-ec`.

## Test plan

- [x] `cargo test -p kobe-arweave` (KATs + uncompressed negative)
- [x] `cargo test -p kobe --all-features --test cross_chain_smoke`
- [x] `cargo test --workspace --all-features`
- [x] `cargo deny check` (advisories/bans/licenses/sources)
- [x] host `check-no-std` includes `kobe-arweave`
- [x] CLI: `kobe arweave import -m "abandon…about" --json` → KAT address
- [ ] CI green (lint / test / deny / no_std thumb)